### PR TITLE
Add MKL-DNN based deep learning framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Intel MKL-DNN is used in the the following software products:
 * [PaddlePaddle\*](http://www.paddlepaddle.org)
 * [Caffe\* Optimized for Intel Architecture](https://github.com/intel/caffe)
 * [Tensorflow\*](https://www.tensorflow.org)
+* [Apache MXNET\*](https://github.com/apache/incubator-mxnet)
 * [DeepBench](https://github.com/baidu-research/DeepBench)
 * [Intel(R) Computer Vision SDK](https://software.intel.com/en-us/computer-vision-sdk)
 * [Intel(R) Nervana(TM) Graph](https://github.com/NervanaSystems/ngraph)


### PR DESCRIPTION
The new MKL-DNN backend is merged ([9677](https://github.com/apache/incubator-mxnet/pull/9677)) into MXNET master branch.
Add a link to MXNET.