### PR TITLE
Add sentinel to enum type mkldnn_memory_format_t

### DIFF
--- a/include/mkldnn.hpp
+++ b/include/mkldnn.hpp
@@ -629,7 +629,7 @@ struct memory: public primitive  {
         ldgoi = mkldnn_ldgoi,
         ldgoi_p = mkldnn_ldgoi_p,
         ldgo = mkldnn_ldgo,
-        format_end = mkldnn_format_end,
+        format_last = mkldnn_format_last,
     };
 
     /// A memory descriptor.

--- a/include/mkldnn.hpp
+++ b/include/mkldnn.hpp
@@ -629,6 +629,7 @@ struct memory: public primitive  {
         ldgoi = mkldnn_ldgoi,
         ldgoi_p = mkldnn_ldgoi_p,
         ldgo = mkldnn_ldgo,
+        format_end = mkldnn_format_end,
     };
 
     /// A memory descriptor.

--- a/include/mkldnn_types.h
+++ b/include/mkldnn_types.h
@@ -272,15 +272,15 @@ typedef enum {
     /** 4D bias tensor in the format (num_layers, num_directions, num_gates,
      * output_channels). */
     mkldnn_ldgo,
+    /** Just a sentinel, not real memory format. Must be changed after new
+     * format is added. */
+    mkldnn_format_last,
     /** 4D weights tensor in the oihw format with input channels data laid out
      * in memory in 8-element blocks. */
     mkldnn_oIhw8i = mkldnn_nChw8c,
     /** 4D weights tensor in the oihw format with input channels data laid out
      * in memory in 16-element blocks. */
     mkldnn_oIhw16i = mkldnn_nChw16c,
-    /** Just as sentinel, not real memory format. May be changed after new
-     * format is added to this list. */
-    mkldnn_format_end = mkldnn_ldgo + 1,
 } mkldnn_memory_format_t;
 
 /** Kinds of padding. Define how to interpret the data in padding regions. */

--- a/include/mkldnn_types.h
+++ b/include/mkldnn_types.h
@@ -278,6 +278,9 @@ typedef enum {
     /** 4D weights tensor in the oihw format with input channels data laid out
      * in memory in 16-element blocks. */
     mkldnn_oIhw16i = mkldnn_nChw16c,
+    /** Just as sentinel, not real memory format. May be changed after new
+     * format is added to this list. */
+    mkldnn_format_end = mkldnn_ldgo + 1,
 } mkldnn_memory_format_t;
 
 /** Kinds of padding. Define how to interpret the data in padding regions. */


### PR DESCRIPTION
I am trying to add a sentinel to enum type `mkldnn_memory_format_t` in mkldnn_types.h. So from framework side, we can set dedicated unit test to monitor the data format change in mkldnn. If new data format is added to mkldnn, we need check framework code to see if code should be adjusted to handle the new data format.

Since a PR should be submitted to mxnet to change the dependency version of mkldnn. If data format is changed in the new version of mkldnn, the dedicated test case will be failed at pre-checkin phase. So this kind of error will not happen in user's workloads.