### PR TITLE
build: link to libdl

### DIFF
--- a/cmake/MKL.cmake
+++ b/cmake/MKL.cmake
@@ -79,6 +79,14 @@ function(detect_mkl LIBNAME)
         endif()
     endif()
 
+    if(UNIX AND LIBNAME MATCHES "mklml.*")
+        # Although MKL-ML depends on shared object functions such as dlopen and
+        # dladdr it is not linked against libdl. This causes link failures when
+        # MKL-DNN is build with the gold linker (e.g. -fuse-ld=gold).
+        list(APPEND EXTRA_LIBS dl)
+        set(EXTRA_LIBS "${EXTRA_LIBS}" PARENT_SCOPE)
+    endif()
+
     if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
         get_filename_component(MKLLIBPATH ${MKLLIB} PATH)
         find_library(MKLIOMP5LIB

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -113,10 +113,3 @@ if(APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${_rpath}")
     endforeach()
 endif()
-
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Although MKL-ML depends on shared object functions such as dlopen and
-    # dladdr it is not linked against libdl. This causes link failures when
-    # MKL-DNN is build with the gold linker (e.g. -fuse-ld=gold).
-    list(APPEND EXTRA_LIBS dl)
-endif()

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -113,3 +113,10 @@ if(APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${_rpath}")
     endforeach()
 endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # Although MKL-ML depends on shared object functions such as dlopen and
+    # dladdr it is not linked against libdl. This causes link failures when
+    # MKL-DNN is build with the gold linker (e.g. -fuse-ld=gold).
+    list(APPEND EXTRA_LIBS dl)
+endif()


### PR DESCRIPTION
When using the gold linker on Linux systems the build fails due to a linkage error. The root cause is that the MKL-ML library uses libdl for shared object functions such as `dlopen` and `dladdr` but does not explicitly link against it. With the (default) BFD linker this does not pose a problem because it resolves these symbols transitively from libiomp5.so's dependency to libdl. However the gold linker has stricter rules for symbol resolution and does not look up transitive references.

See [this link](https://fedoraproject.org/wiki/GoldIncompatibilities) for more information about the incompatibilities between gold and BFD linkers.

Below is the typical `undefined reference` error when building with the gold linker:

```
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CCXX_FLAGS='-fuse-ld=gold' ..
cmake --build .

[ 40%] Linking CXX executable simple-training-net-cpp
/home/balioglu/repos/mkl-dnn/external/mklml_lnx_2018.0.3.20180406/lib/libmklml_intel.so: error: undefined reference to 'dladdr'
/home/balioglu/repos/mkl-dnn/external/mklml_lnx_2018.0.3.20180406/lib/libmklml_intel.so: error: undefined reference to 'dlopen'
/home/balioglu/repos/mkl-dnn/external/mklml_lnx_2018.0.3.20180406/lib/libmklml_intel.so: error: undefined reference to 'dlerror'
/home/balioglu/repos/mkl-dnn/external/mklml_lnx_2018.0.3.20180406/lib/libmklml_intel.so: error: undefined reference to 'dlsym'
collect2: error: ld returned 1 exit status
```

The fix is a small conditional statement that adds libdl to `EXTRA_LIBS` in platform.cmake.

Tested on Ubuntu 16.04, Amazon Linux 2017.03, and macOS Sierra.