### PR TITLE
fix -Werror=missing-field-initializers in GCC48 compiler

### DIFF
--- a/include/mkldnn.hpp
+++ b/include/mkldnn.hpp
@@ -794,7 +794,7 @@ struct memory: public primitive  {
 };
 
 inline memory::desc zero_md() {
-    mkldnn_memory_desc_t zero{};
+    mkldnn_memory_desc_t zero;
     zero.primitive_kind = mkldnn_memory;
     return memory::desc(zero);
 }


### PR DESCRIPTION
fix #237