### PR TITLE
Enables OpenMP with MSVC

### DIFF
--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -150,7 +150,7 @@ void _gemm_convolution_bwd_data_t<run_jit, isa>::execute_backward_data() {
 
         if (jcp.id > 1) {
         #pragma omp for
-        for (size_t i = 0; i < jcp.ngroups*jcp.mb*src_step; ++i)
+        for (long i = 0; i < jcp.ngroups*jcp.mb*src_step; ++i)
             diff_src[i] = 0.;
         }
 
@@ -295,7 +295,9 @@ void _gemm_convolution_bwd_weights_t<run_jit, isa>::execute_backward_weights() {
                     size_t offset = offset_ + mb*jcp.ngroups*dst_step;
                     for (int od = 0; od < jcp.od; ++od)
                     for (int oh = 0; oh < jcp.oh; ++oh)
-#                   pragma omp simd reduction(+:db)
+#ifndef _MSC_VER
+                    #pragma omp simd reduction(+:db)
+#endif // _MSC_VER
                     for (int ow = 0; ow < jcp.ow; ++ow)
                     {
                         db += diff_dst[offset];

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -224,7 +224,10 @@ void im2col_u8(
                     const size_t im_idx
                         = (ih * jcp.iw + iw) * jcp.ngroups * jcp.ic;
 
-#                   pragma omp simd
+					#ifndef _MSC_VER
+					#pragma omp simd
+					#endif // _MSC_VER
+                    
                     for (int ic = 0; ic < jcp.ic; ++ic) {
                         col[col_idx + ic] = im[im_idx + ic];
                     }
@@ -291,7 +294,9 @@ void col2im(
     for (int ic = 0; ic < jcp.ic; ++ic) {
         float *im_ = im + ic * im_step;
         const float *col_ = col + ic * col_step;
-#       pragma omp simd
+		#ifndef _MSC_VER
+		#pragma omp simd
+		#endif // _MSC_VER
         for (int is = 0; is < iS; ++is) im_[is] = 0.;
 
         for (int kh = 0; kh < jcp.kh; ++kh) {
@@ -378,7 +383,8 @@ status_t prepare_ws_col(jit_gemm_conv_conf_t &jcp, src_t **col, const int nthr) 
     if (*col == nullptr) return status::out_of_memory;
 
 #   pragma omp parallel for
-    for (size_t i = 0; i < im2col_sz; ++i) (*col)[i] = (src_t)0;
+    for (long i = 0; i < im2col_sz; ++i)
+        (*col)[i] = (src_t)0;
 
     return status::success;
 }

--- a/src/cpu/gemm_inner_product.cpp
+++ b/src/cpu/gemm_inner_product.cpp
@@ -157,13 +157,17 @@ void gemm_inner_product_bwd_weights_t<data_type>::execute_backward_weights() {
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (cblas_int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (cblas_int mb = 1; mb < MB; ++mb) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (cblas_int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/jit_avx2_1x1_convolution.cpp
@@ -508,7 +508,9 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights() {
                     for (int o = 0; o < 8; ++o) d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 8;

--- a/src/cpu/jit_avx2_convolution.cpp
+++ b/src/cpu/jit_avx2_convolution.cpp
@@ -300,7 +300,9 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights() {
                         d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 8;

--- a/src/cpu/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/jit_avx512_common_1x1_convolution.cpp
@@ -437,7 +437,7 @@ jit_avx512_common_1x1_convolution_bwd_weights_t ::
             jcp.nthr_mb * jcp.ngroups * jcp.ic * jcp.tr_is;
         tr_src_ = (data_t *)malloc(tr_src_size * sizeof(data_t), 64);
 #       pragma omp parallel for
-        for (size_t i = 0; i < tr_src_size; i++)
+        for (long i = 0; i < tr_src_size; i++)
             tr_src_[i] = 0;
         auto tp = jit_transpose4x16_src_t();
         tp.src_pf0_distance = 4;
@@ -759,7 +759,9 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights()
                         d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (int o = 0; o < 16; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 16;

--- a/src/cpu/jit_avx512_common_convolution.cpp
+++ b/src/cpu/jit_avx512_common_convolution.cpp
@@ -806,20 +806,26 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const int tr_iw = jcp.tr_iw;
 
         for (size_t iwork = start; iwork < end; iwork++) {
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
 #           pragma unroll
             for (int i = 0; i < l_pad; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
                     tr_src1[j * jcp.tr_iw + i] = (src_data_t)0.0;
 
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
 #           pragma unroll
             for (int i = l_pad; i < iwlp; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
                     tr_src1[j * jcp.tr_iw + i]
                         = (src_data_t)src1[(i - l_pad) * 16 + j];
 
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
 #           pragma unroll
             for (int i = iwlp; i < tr_iw; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
@@ -1245,7 +1251,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 for (int o = 0; o < 16; ++o)
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (int o = 0; o < 16; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += 16;

--- a/src/cpu/jit_avx512_common_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_common_convolution_winograd.cpp
@@ -46,7 +46,9 @@ void inline load_ps(float *dest, const float *src_mem) {
     __m512 *Iv512 = (__m512 *)dest;
     Iv512[0] = _mm512_load_ps(src_mem);
 #else
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
     for (int v = 0; v < simd_w; v++) dest[v] = src_mem[v];
 #endif
 }
@@ -58,7 +60,9 @@ void inline store_output(float *dest, const float *data, bool streamout) {
     else
         _mm512_store_ps(dest, *((__m512 *)data));
 #else
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
     for (int v = 0; v < simd_w; v++)
         dest[v] = data[v];
 #endif
@@ -77,15 +81,21 @@ void inline accum_output(
     else
         _mm512_store_ps(dest, _data);
 #else
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
     for (int v = 0; v < simd_w; v++)
         data[v] += dest[v];
     if (with_relu_postsum)
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int v = 0; v < simd_w; v++)
             if (data[v] < 0.f)
                 data[v] = 0.f;
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
     for (int v = 0; v < simd_w; v++)
         dest[v] = data[v];
 #endif
@@ -106,7 +116,9 @@ void trans_W_4x4_3x3(float Fw_[6][6][16][16], float F[3][3][16][16]) {
     for (int j = 0; j < 16; j++) {
 #pragma unroll
         for (int i = 0; i < 3; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int k = 0; k < 16; k++) {
                 t0[k] = 0.26890756302521f * F[2][i][j][k];
                 t1[k] = -t0[k] - 0.688403361344538f * F[0][i][j][k];
@@ -122,7 +134,9 @@ void trans_W_4x4_3x3(float Fw_[6][6][16][16], float F[3][3][16][16]) {
         }
 #pragma unroll
         for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int k = 0; k < 16; k++) {
                 t0[k] = 0.26890756302521f * T[i][2][k];
                 t1[k] = -t0[k] - 0.688403361344538f * T[i][0][k];
@@ -152,7 +166,9 @@ void trans_O_4x4_3x3(float Mw[6][6][16], float O[4][4][16]) {
 
 #pragma unroll
     for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int v = 0; v < 16; v++) {
             t0[v] = Mw[1][i][v] + Mw[2][i][v];
             t1[v] = Mw[3][i][v] + Mw[4][i][v];
@@ -167,7 +183,9 @@ void trans_O_4x4_3x3(float Mw[6][6][16], float O[4][4][16]) {
     }
 #pragma unroll
     for (int i = 0; i < 4; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int v = 0; v < 16; v++) {
             t0[v] = T[i][1][v] + T[i][2][v];
             t1[v] = T[i][3][v] + T[i][4][v];
@@ -199,7 +217,9 @@ void trans_W_3x3_4x4(float Fw[6][6][16], float F[4][6][16])
 
 pragma_unroll
     for (int i = 0; i < 4; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < 16; j++) {
             t0[j] = F[2][i][j] * rcp6;
             t1[j] = F[0][i][j] * -rcp6 - t0[j];
@@ -217,7 +237,9 @@ pragma_unroll
     }
 pragma_unroll
     for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < 16; j++) {
             t0[j] = T[i][2][j] * rcp6;
             t1[j] = T[i][0][j] * -rcp6 - t0[j];
@@ -246,7 +268,9 @@ void trans_O_3x3_4x4(float Mw[6][6][16][16], float M[3][3][16][16])
     for (int j = 0; j < 16; j++) {
 pragma_unroll
         for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int l = 0; l < 16; l++) {
                 t0[l] = Mw[1][i][j][l] + Mw[2][i][j][l];
                 t1[l] = Mw[3][i][j][l] + Mw[4][i][j][l];
@@ -260,7 +284,9 @@ pragma_unroll
         }
 pragma_unroll
         for (int i = 0; i < 3; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int l = 0; l < 16; l++) {
                 t0[l] = T[i][1][l] + T[i][2][l];
                 t1[l] = T[i][3][l] + T[i][4][l];
@@ -291,7 +317,9 @@ void trans_I_4x4_3x3(float Iw[6][6][16], float I[6][6][16])
 
 pragma_unroll
     for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int v = 0; v < 16; v++) {
             t0[v] = I[2][i][v] * -2.25f + I[4][i][v];
             t1[v] = I[1][i][v] * -2.25f + I[3][i][v];
@@ -311,7 +339,9 @@ pragma_unroll
 
 pragma_unroll
     for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int v = 0; v < 16; v++) {
             t0[v] = T[i][2][v] * -2.25f + T[i][4][v];
             t1[v] = T[i][1][v] * -2.25f + T[i][3][v];
@@ -341,7 +371,9 @@ void trans_W_3x3_4x4_wu(float Fw[6][6][16], float F[4][6][16])
 
 pragma_unroll
     for (int i = 0; i < 4; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int v = 0; v < 16; v++) {
             t0[v] = F[2][i][v] * 0.26890756302521f;
             t1[v] = F[0][i][v] * -0.688403361344538f - t0[v];
@@ -391,7 +423,9 @@ void trans_O_3x3_4x4_wu(float Mw[6][6][16][16], float M[3][3][16][16])
     for (int j = 0; j < 16; j++) {
 pragma_unroll
         for (int i = 0; i < 6; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int v = 0; v < 16; v++) {
                 t0[v] = Mw[1][i][j][v] + Mw[2][i][j][v];
                 t1[v] = Mw[3][i][j][v] + Mw[4][i][j][v];
@@ -405,7 +439,9 @@ pragma_unroll
         }
 pragma_unroll
         for (int i = 0; i < 3; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int v = 0; v < 16; v++) {
                 t0[v] = T[i][1][v] + T[i][2][v];
                 t1[v] = T[i][3][v] + T[i][4][v];
@@ -419,7 +455,9 @@ pragma_unroll
 
 pragma_unroll
             for (int k = 0; k < 3; k++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v = 0; v < 16; v++) {
                     M[i][k][j][v] = M_[k][v];
                 }
@@ -468,7 +506,9 @@ void input_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                             float *pinp_i = pinp_j + (xdim - l_pad) * 16;
                             load_ps(I[j][i], pinp_i);
                         } else {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -476,7 +516,9 @@ void input_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -551,7 +593,9 @@ void input_transform_tileblock_data(int tile_block,
                             float *pinp_i = pinp_j + (xdim - l_pad) * simd_w;
                             load_ps(I[j][i], pinp_i);
                         } else {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -559,7 +603,9 @@ void input_transform_tileblock_data(int tile_block,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -607,7 +653,9 @@ void weight_transform_data(const jit_conv_winograd_conf_t &jcp,
                 float *base_inp = is_fwd
                                 ? &(input(0, 0, j, i, v1, 0))
                                 : &(input(0, 0, 2 - j, 2 - i, v1, 0));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v2 = 0; v2 < simd_w; v2++) {
                     if (is_fwd)
                         F[j][i][v1][v2] = *(base_inp + v2);
@@ -623,7 +671,9 @@ void weight_transform_data(const jit_conv_winograd_conf_t &jcp,
     for (int j = 0; j < alpha; j++) {
         for (int i = 0; i < alpha; i++) {
             for (int v1 = 0; v1 < simd_w; v1++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v2 = 0; v2 < simd_w; v2++) {
                     output(0, j, i, 0, 0, 0, v1, v2) = Fw[j][i][v1][v2];
                 }
@@ -661,7 +711,9 @@ void output_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
         for (int ti = 0; ti < jcp.itiles; ti++) {
             for (int j = 0; j < alpha; j++) {
                 for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int v = 0; v < simd_w; v++) {
                         Ow[j][i][v] = input(tile_block, 0,
                                 j, i,
@@ -682,7 +734,9 @@ void output_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                         if (xdim < outw) {
                             float *pout_i = pout_j + xdim * simd_w;
                             if (is_fwd) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                                 for (int v = 0; v < simd_w; v++) {
                                     O[j][i][v] += with_bias ? bias[v] : 0.f;
                                     O[j][i][v] = true
@@ -766,7 +820,9 @@ void output_transform_tileblock_data(int tile_block,
                         if (xdim < outw) {
                             float *pout_i = pout_j + xdim * simd_w;
                             if (is_fwd) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                                 for (int v = 0; v < simd_w; v++) {
                                     O[j][i][v] += with_bias ? bias[v] : 0.f;
                                     O[j][i][v] = true
@@ -830,14 +886,18 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     for (int i = 0; i < alpha; i++) {
                         int xdim = ti * tile_size + i;
                         if ((conv.l_pad <= xdim) && xdim < ifwp) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input(0, 0,
                                         ydim - conv.t_pad,
                                         xdim - conv.l_pad, v);
                             }
                         } else {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -845,7 +905,9 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -859,7 +921,9 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     for (int i = 0; i < alpha; i++) {
                         float *Iw_temp_base = &(Iw_trans_temp(j, i,
                                                         tile_4fma, 0));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             Iw_temp_base[v] = Iw[j][i][v];
                         }
@@ -903,7 +967,9 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
             for (int i = 0; i < alpha; i++) {
                 for (int tb = tile_4fma; tb < conv.tile_4fma; tb++) {
                     float *Iw_temp_base = &(Iw_trans_temp(j, i, tb, 0));
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (int v = 0; v < simd_w; v++) {
                         Iw_temp_base[v] = 0;
                     }
@@ -951,18 +1017,24 @@ void diff_dst_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                         int xdim = ti * tile_size + i;
                         if (xdim < conv.ow) {
                             float *input_base = &(input(0, 0, ydim, xdim, 0));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input_base[v];
                             }
                             if (with_bias && j < tile_size && i < tile_size) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                                 for (int v = 0; v < simd_w; v++) {
                                     dbias[v] += input_base[v];
                                 }
                             }
                         } else {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -970,7 +1042,9 @@ void diff_dst_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1023,7 +1097,9 @@ void diff_weights_transform_bwd_weights(jit_conv_winograd_conf_t conv,
     for (int j = 0; j < alpha; j++) {
         for (int i = 0; i < alpha; i++) {
             for (int v = 0; v < conv.ic_simd_block; v++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int k = 0; k < conv.oc_simd_block; k++) {
                     Fw[j][i][v][k] = input(0, 0, j, i, 0, 0, v, k);
                 }
@@ -1416,7 +1492,9 @@ _execute_backward_weights_S_D_G_W()
 
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -1511,7 +1589,9 @@ _execute_backward_weights_S_D_G_W()
                     float* base_bias_ptr = &(diff_bias(ofm1, 0));
                     float* base_bias_prv_ptr = &(diff_bias_prv(
                                 ithr * jcp.oc + ofm1 * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                         base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                     }
@@ -1569,7 +1649,9 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                     for (int i = 0; i < alpha; i++) {
                         int xdim = ti * tile_size + i;
                         if ((conv.l_pad <= xdim) && xdim < ifwp) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input(img, 0,
                                     ydim - conv.t_pad,
@@ -1577,7 +1659,9 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                             }
                         }
                         else {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1586,7 +1670,9 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                 }
                 else {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1599,7 +1685,9 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
             if (ver_4fma) {
                 for (int j = 0; j < alpha; j++) {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             Iw_scratchpad(j, i, tile_4fma, v) = Iw[j][i][v];
                         }
@@ -1662,19 +1750,25 @@ void diff_dst_transform_bwd_weights_tile(int tile_block,
                         int xdim = ti * tile_size + i;
                         if (xdim < conv.ow) {
                             float *input_base = &input(img, 0, ydim, xdim, 0);
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input_base[v];
                             }
                             if (with_bias && j < tile_size && i < tile_size) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                                 for (int v = 0; v < simd_w; v++) {
                                     dbias[v] += input_base[v];
                                 }
                             }
                         }
                         else {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1683,7 +1777,9 @@ void diff_dst_transform_bwd_weights_tile(int tile_block,
                 }
                 else {
                     for (int i = 0; i < alpha; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1725,13 +1821,17 @@ void array_sum(int num_arrs, float *output,
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
             if (!reduce_to_first) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1742,13 +1842,17 @@ void array_sum(int num_arrs, float *output,
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
             if (!reduce_to_first) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1777,22 +1881,30 @@ void subarray_sum(int num_arrs, float *output, size_t nelems,
             size_t end_e = start_e + block_size;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (int a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1804,22 +1916,30 @@ void subarray_sum(int num_arrs, float *output, size_t nelems,
             size_t end_e = nelems;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (int a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1898,7 +2018,9 @@ _execute_backward_weights_S_D_Giot_W()
             }
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -2022,7 +2144,9 @@ _execute_backward_weights_S_D_Giot_W()
                 float* base_bias_ptr = &(diff_bias(ofm1, 0));
                 float* base_bias_prv_ptr = &(diff_bias_prv(
                             ithr * jcp.oc + ofm1 * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                     base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                 }
@@ -2088,7 +2212,9 @@ _execute_backward_weights_SDGtWo()
                 }
 #pragma omp for nowait
                 for (int bofm = 0; bofm < jcp.oc_block; bofm++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int v = 0; v < simd_w; v++)
                         diff_bias(ofm1, bofm, v) = 0.0f;
                 }
@@ -2170,7 +2296,9 @@ _execute_backward_weights_SDGtWo()
                     float* base_bias_ptr = &(diff_bias(ofm1, ofm2, 0));
                     float* base_bias_prv_ptr = &(diff_bias_prv(
                                 ithr * jcp.oc_block * simd_w + ofm2 * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int ofm3 = 0; ofm3 < simd_w; ofm3++) {
                         base_bias_ptr[ofm3] += base_bias_prv_ptr[ofm3];
                     }
@@ -2239,7 +2367,9 @@ _execute_backward_weights_SDGt_W()
             }
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -2332,7 +2462,9 @@ _execute_backward_weights_SDGt_W()
                 float* base_bias_ptr = &(diff_bias(ofm1, 0));
                 float* base_bias_prv_ptr = &(diff_bias_prv(
                             ithr * jcp.oc + ofm1 * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                     base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                 }

--- a/src/cpu/jit_avx512_core_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_core_convolution_winograd.cpp
@@ -625,13 +625,17 @@ void array_sum(size_t num_arrs, float *output,
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
             if (!reduce_to_first) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (size_t a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -642,13 +646,17 @@ void array_sum(size_t num_arrs, float *output,
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
             if (!reduce_to_first) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (size_t a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }

--- a/src/cpu/jit_avx512_core_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_core_convolution_winograd.cpp
@@ -554,22 +554,30 @@ void subarray_sum(size_t num_arrs, float *output, size_t nelems,
             size_t end_e = start_e + block_size;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (size_t a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -581,22 +589,30 @@ void subarray_sum(size_t num_arrs, float *output, size_t nelems,
             size_t end_e = nelems;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (size_t a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -727,7 +743,9 @@ _execute_backward_weights_SDGtWo() {
         for (int ithr = 0; ithr < nthreads; ithr++) {
             for (int ofm = 0; ofm < jcp.oc / simd_w; ofm++) {
                 float *pdbias = &(diff_bias_prv(ithr, ofm * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int v = 0; v < simd_w; v++) {
                     pdbias[v] = 0.0f;
                 }
@@ -1029,13 +1047,17 @@ _execute_backward_weights_S_D_Giot_W() {
         for (int ofm1 = 0; ofm1 < jcp.oc / simd_w; ++ofm1) {
             float* pbias = &(diff_bias(ofm1 * simd_w));
             float *pbias_prv = &(diff_bias_prv(0, ofm1 * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
             for (int ofm2 = 0; ofm2 < simd_w; ++ofm2) {
                 pbias[ofm2] = pbias_prv[ofm2];
             }
             for (int ithr = 1; ithr < nthreads; ++ithr) {
                 pbias_prv = &(diff_bias_prv(ithr, ofm1 * simd_w));
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int ofm2 = 0; ofm2 < simd_w; ++ofm2) {
                     pbias[ofm2] += pbias_prv[ofm2];
                 }

--- a/src/cpu/jit_uni_inner_product.cpp
+++ b/src/cpu/jit_uni_inner_product.cpp
@@ -114,13 +114,17 @@ void jit_uni_inner_product_bwd_weights_t<isa>::execute_backward_weights()
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (int mb = 1; mb < MB; ++mb) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -24,6 +24,8 @@
 
 #include "nchw_pooling.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/ncsp_batch_normalization.cpp
+++ b/src/cpu/ncsp_batch_normalization.cpp
@@ -131,7 +131,9 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = (c + C_off) * SP;
                     data_t sum = 0;
                     for (int n = N_s; n < N_e; ++n)
+#ifndef _MSC_VER
 #pragma omp simd reduction(+ : sum)
+#endif // _MSC_VER
                         for (int sp = S_s; sp < S_e; ++sp) {
                             sum += src[off + n * C * SP + sp];
                         }
@@ -149,7 +151,9 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = c + C_off;
                     data_t sum = 0.;
                     for (int n = N_s; n < N_e; ++n)
+#ifndef _MSC_VER
 #pragma omp simd reduction(+ : sum)
+#endif // _MSC_VER
                         for (int sp = S_s; sp < S_e; ++sp) {
                             data_t m = src[off * SP + n * C * SP + sp]
                                     - mean[off];
@@ -173,7 +177,9 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                 data_t sqrt_variance
                         = static_cast<data_t>(1.0f / sqrtf(variance[off] + eps));
                 for (int n = N_s; n < N_e; ++n)
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int sp = S_s; sp < S_e; ++sp) {
                         size_t d_off = off * SP + n * C * SP + sp;
                         data_t bn_res
@@ -275,7 +281,9 @@ void ncsp_batch_normalization_bwd_t::execute_backward() {
                 data_t diff_gamma = 0.0, diff_beta = 0.0;
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
+#ifndef _MSC_VER
 #pragma omp simd reduction(+ : diff_gamma, diff_beta)
+#endif // _MSC_VER
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         data_t dd;
@@ -312,7 +320,9 @@ void ncsp_batch_normalization_bwd_t::execute_backward() {
                         = static_cast<data_t>(1.0f / sqrtf(variance[off] + eps));
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         ;

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -340,7 +340,9 @@ void nhwc_pooling_bwd_t<data_type>::execute_backward() {
                                                        ow, ws_w_stride);
                 const int index = kd * KH * KW + kh * KW + kw;
 
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int oc = 0; oc < OC; ++oc) {
                     const int index_from_ws =
                                     (MEM_D(ws).data_type() == data_type::u8)
@@ -375,7 +377,9 @@ void nhwc_pooling_bwd_t<data_type>::execute_backward() {
                 auto num_summands = (alg == pooling_avg_include_padding)
                   ? KW*KH*KD
                   : (ih_end - ih_start)*(iw_end - iw_start)*(id_end - id_start);
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int oc = 0; oc < OC; ++oc) {
                     const data_t d = diff_dst[dst_offset_init + oc];
                     // Check if kernel windows are disjoint, in this case

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -24,6 +24,8 @@
 
 #include "nhwc_pooling.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -114,7 +114,9 @@ private:
     {
         assert(!((use_workspace == false) ^ (!ws))); // ensure ws pointer exists
 
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int oc = 0; oc < n; ++oc) {
             auto s = src[oc];
             data_t mv = dst[oc];

--- a/src/cpu/nspc_batch_normalization.cpp
+++ b/src/cpu/nspc_batch_normalization.cpp
@@ -101,7 +101,9 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
             for (int n = N_s; n < N_e; n++)
                 for (int sp = 0; sp < SP; sp++)
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int c = 0; c < C; c++)
                         ws_reduce[C * ithr + c] += src[(size_t)n * SP * C
                             + sp * C + c];
@@ -121,7 +123,9 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
             for (int n = N_s; n < N_e; n++)
                 for (int sp = 0; sp < SP; sp++)
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                     for (int c = 0; c < C; c++) {
                         data_t m = src[(size_t)n * SP * C + sp * C + c]
                             - mean_loc[c];
@@ -144,7 +148,9 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
         for (int n = N_s; n < N_e; n++) {
             for (int sp = 0; sp < SP; sp++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int c = 0; c < C; c++) {
                     data_t sqrt_variance = static_cast<data_t>(
                             1.0f / sqrtf(variance_loc[c] + eps));
@@ -227,7 +233,9 @@ void nspc_batch_normalization_bwd_t::execute_backward() {
 
         for (int n = N_s; n < N_e; n++)
             for (int sp = 0; sp < SP; sp++)
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int c = 0; c < C; c++) {
                     const size_t d_off = (size_t)n * SP * C + sp * C + c;
                     data_t dd;
@@ -259,7 +267,9 @@ void nspc_batch_normalization_bwd_t::execute_backward() {
 
         for (int n = N_s; n < N_e; n++) {
             for (int sp = 0; sp < SP; sp++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
                 for (int c = 0; c < C; c++) {
                     const size_t d_off = (size_t)n * SP * C + sp * C + c;
                     data_t gamma = use_scaleshift ? scaleshift[c] : 1;

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -20,6 +20,8 @@
 #include "math_utils.hpp"
 #include "ref_deconvolution.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -73,7 +75,9 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_ncdhw() {
 #   pragma omp parallel for collapse(2) schedule(static)
     for (int mb = 0; mb < MB; ++mb) {
         for (int oc = 0; oc < OC; ++oc) {
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = ((mb * OC + oc) * SP + sp );
                 dst[offset] += bias[oc];
@@ -98,7 +102,9 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_nCdhwXc() {
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = ((mb * OC + oc*blksize)
                     * SP + sp * blksize) ;
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (int i=0; i<blksize; i++)
                     dst[offset + i] += bias[oc*blksize + i];
             }
@@ -159,7 +165,9 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ncdhw() {
     for (int oc = 0; oc < OC; ++oc) {
         data_t db = 0;
         for (int mb = 0; mb < MB; ++mb) {
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = (mb * OC + oc) * SP + sp;
                 db += diff_dst[offset];
@@ -187,12 +195,16 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc() {
         for (int mb = 0; mb < MB; ++mb) {
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = (mb * OC + oc*blksize) * SP + sp * blksize;
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (int i = 0; i<blksize; i++)
                     db[i] += diff_dst[offset+i];
             }
         }
-#       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
         for (int i = 0; i<blksize; i++)
             diff_bias[oc*blksize+i] = db[i];
     }

--- a/src/cpu/ref_inner_product.cpp
+++ b/src/cpu/ref_inner_product.cpp
@@ -227,13 +227,17 @@ void ref_inner_product_bwd_weights_t<data_type>::execute_backward_weights() {
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (int mb = 1; mb < MB; ++mb) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/ref_lrn.cpp
+++ b/src/cpu/ref_lrn.cpp
@@ -22,6 +22,8 @@
 
 #include "ref_lrn.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -116,7 +118,9 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
         {
             const size_t off = (size_t)(mb * CHW + c * H * W + (h * W + w)
                 * blksize);
-            # pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (int cc = 0; cc < blksize; ++cc)
                 ker(&dst[off + cc], mb, c + cc, h, w);
         }
@@ -215,7 +219,9 @@ void ref_lrn_bwd_t<data_type>::execute_backward() {
         {
             const size_t off = (size_t)(mb * CHW + c * H * W + (h * W + w)
                 * blksize);
-            # pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (int cc = 0; cc < blksize; ++cc)
                 ker(&diff_src[off + cc], mb, c + cc, h, w);
         }

--- a/src/cpu/ref_rnn.cpp
+++ b/src/cpu/ref_rnn.cpp
@@ -35,6 +35,8 @@
 
 #include "ref_rnn.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/ref_rnn.cpp
+++ b/src/cpu/ref_rnn.cpp
@@ -117,7 +117,9 @@ elemwise_sig(_ref_rnn_common_t<prop_kind::forward>::lstm_elemwise) {
 
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < dic; j++) {
             ws_gates(i, 0, j) = logistic_fwd(ws_gates(i, 0, j) + bias(0, j));
             ws_gates(i, 1, j) = logistic_fwd(ws_gates(i, 1, j) + bias(1, j));
@@ -148,7 +150,9 @@ elemwise_sig(_ref_rnn_common_t<prop_kind::backward>::lstm_elemwise) {
 
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < dic; j++) {
             float Ct = states_t_l(1, i, j);
             /// @todo save it in the workspace in fwd pass or recompute it to
@@ -279,7 +283,9 @@ cell_execution_sig(_ref_rnn_common_t<prop_kind::forward>::cell_execution_gru) {
     // 3. activation zt and rt + elemwise multiplication rt,ht-1
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < dic; j++) {
             ws_gates(i, 0, j) = logistic_fwd(ws_gates(i, 0, j) + bias(0, j));
             ws_gates(i, 1, j) = logistic_fwd(ws_gates(i, 1, j) + bias(1, j));
@@ -295,7 +301,9 @@ cell_execution_sig(_ref_rnn_common_t<prop_kind::forward>::cell_execution_gru) {
     // 5. activation h~t + calculate ht
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < dic; j++) {
             ws_gates(i, 2, j) = tanh_fwd(ws_gates(i, 2, j) + bias(2, j));
             states_t_l(i, j) = states_tm1_l(i, j) * ws_gates(i, 0, j) +
@@ -326,7 +334,9 @@ cell_execution_sig(_ref_rnn_common_t<prop_kind::backward>::cell_execution_gru) {
     // dht-1 (part) = dh * G0
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < dic; j++) {
             float h = states_tm1_l(i, j);
             float dHt = diff_states_tp1_l(0, i, j)
@@ -354,7 +364,9 @@ cell_execution_sig(_ref_rnn_common_t<prop_kind::backward>::cell_execution_gru) {
     //h * G1 (required for dWh)
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
+#ifndef _MSC_VER
 #pragma omp simd
+#endif // _MSC_VER
         for (int j = 0; j < dic; j++) {
             float h = states_tm1_l(i, j);
             float G1 =  ws_gates(i, 1, j);

--- a/src/cpu/simple_concat.cpp
+++ b/src/cpu/simple_concat.cpp
@@ -16,6 +16,8 @@
 
 #include "simple_concat.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -49,7 +51,7 @@ void simple_concat_t<data_type>::execute() {
     for (int i = 0; i < perm[concat_dim]; i++)
         os[i] = o_d.blocking_desc().strides[0][iperm[i]];
     dims_t phys_dims;
-    for (size_t i = 0; i < sizeof(phys_dims)/sizeof(phys_dims[0]); i++)
+    for (long i = 0; i < sizeof(phys_dims) / sizeof(phys_dims[0]); i++)
         phys_dims[i] = (i < (size_t)perm[concat_dim]) ?
                 o_d.dims()[iperm[i]] / blk.block_dims[iperm[i]] :
                 1;
@@ -60,7 +62,7 @@ void simple_concat_t<data_type>::execute() {
             const data_t *i = &input_ptrs[a][0];
             data_t *o = &output_ptrs[a][0];
 #           pragma omp parallel for
-            for (size_t e = 0; e < nelems_to_copy[a]; ++e)
+            for (long e = 0; e < nelems_to_copy[a]; ++e)
                 o[e] = i[e];
         }
         break;
@@ -80,7 +82,9 @@ void simple_concat_t<data_type>::execute() {
                                         + os[2] * n2 + os[3] * n3 + os[4] * n4;
                                 const data_t *i = &input_ptrs[a][in_off];
                                 data_t *o = &output_ptrs[a][out_off];
-#                               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                                 for (size_t e = 0; e < nelems_to_copy[a]; ++e)
                                     o[e] = i[e];
                             }

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -30,6 +30,8 @@
 
 #include "simple_q10n.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -247,7 +249,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c], rmode);
@@ -256,7 +260,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c],
@@ -266,7 +272,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c], alpha, rmode);
@@ -275,7 +283,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c],
@@ -287,7 +297,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c], rmode);
@@ -296,7 +308,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c],
@@ -306,7 +320,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c], alpha, rmode);
@@ -315,7 +331,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c],
@@ -368,7 +386,10 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nsize) {
             if (alpha == 1.0 && beta == 0) {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
+                
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] =
@@ -376,7 +397,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] = data_t<type_o>(
@@ -492,7 +515,10 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w], rmode);
@@ -501,7 +527,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w],
@@ -511,7 +539,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w], alpha, rmode);
@@ -520,7 +550,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w],
@@ -532,7 +564,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c], rmode);
@@ -541,7 +575,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c],
@@ -551,7 +587,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c], alpha, rmode);
@@ -560,7 +598,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c],
@@ -657,7 +697,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nrows, const int ncols) {
             if (alpha == 1.0 && beta == 0) {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -668,7 +710,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -717,7 +761,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0) {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -730,7 +776,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? O * os[0] + oc :
@@ -1305,7 +1353,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0.0) {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -1318,7 +1368,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+#ifndef _MSC_VER
+#pragma omp simd collapse(2)
+#endif // _MSC_VER
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? ic * blksize + oc :
@@ -1751,25 +1803,33 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
             round_mode_t rmode = pd->attr()->round_mode_;
 
             if (alpha == 1.0 && beta == 0.0) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_a1b0<data_t<type_i>, data_t<type_o>>()
                                 (input[e], rmode);
                 }
             } else if (alpha == 1.0) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_a1<data_t<type_i>, data_t<type_o>>()
                                 (input[e], output[e], beta, rmode);
                 }
             } else if (beta == 0.0) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_b0<data_t<type_i>, data_t<type_o>>()
                                 (input[e], alpha, rmode);
                 }
             } else {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz<data_t<type_i>, data_t<type_o>>()
                                 (input[e], output[e], alpha, beta, rmode);
@@ -1778,25 +1838,33 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
             if (rem_elems != 0 && ithr == nthr - 1){
                 if (alpha == 1.0 && beta == 0.0) {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_a1b0<data_t<type_i>,
                             data_t<type_o>>()(input[e], rmode);
                     }
                 } else if (alpha == 1.0) {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_a1<data_t<type_i>,
                             data_t<type_o>>()(input[e], output[e], beta, rmode);
                     }
                 } else if (beta == 0.0) {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_b0<data_t<type_i>,
                             data_t<type_o>>()(input[e], alpha, rmode);
                     }
                 } else {
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz<data_t<type_i>, data_t<type_o>>()
                                     (input[e], output[e], alpha, beta, rmode);
@@ -1852,7 +1920,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     size_t dim1_e =
                         dim1_s + work_rem > nelems_no_d0 ? nelems_no_d0
                         : dim1_s + work_rem;
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (size_t e = dim1_s; e < dim1_e; ++e){
                         output[os * n + e] = data_t<type_o>(input[is * n + e]);
                     }
@@ -1873,7 +1943,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     size_t dim1_e =
                         dim1_s + work_rem > nelems_no_d0 ? nelems_no_d0
                         : dim1_s + work_rem;
-#                   pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                     for (size_t e = dim1_s; e < dim1_e; ++e){
                         output[os * n + e] = data_t<type_o>(
                                 alpha * input[is * n + e]
@@ -1936,8 +2008,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         const float *scales = pd->attr()->output_scales_.scales_;
 
 #       pragma omp parallel for collapse(2)
-        for (size_t dm = 0; dm < D_mask; ++dm)
-        for (size_t dr = 0; dr < D_rest; ++dr) {
+        for (long dm = 0; dm < D_mask; ++dm)
+        for (long dr = 0; dr < D_rest; ++dr) {
             const float scale = scales[dm];
 
             const size_t e = dm * D_rest + dr;

--- a/src/cpu/simple_sum.cpp
+++ b/src/cpu/simple_sum.cpp
@@ -52,12 +52,16 @@ void simple_sum_t<data_type>::execute() {
         for (size_t nb = start; nb < end; ++nb) {
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (size_t e = start_e; e < end_e; e++) {
                 output[e] = data_t(scales[0] * input_ptrs[0][e]);
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += data_t(scales[a] * input_ptrs[a][e]);
                 }
@@ -67,12 +71,16 @@ void simple_sum_t<data_type>::execute() {
         if (tail != 0 && ithr == nthr - 1) {
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
-#           pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
             for (size_t e = start_e; e < end_e; e++) {
                 output[e] = data_t(scales[0] * input_ptrs[0][e]);
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+#ifndef _MSC_VER
+#pragma omp simd
+#endif // _MSC_VER
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += data_t(scales[a] * input_ptrs[a][e]);
                 }


### PR DESCRIPTION
These changes enable users to enable OpenMP support when using Microsoft's compiler. The only real issue here is about a 100 or so declarations of `pragma omp simd`. MSVC does auto-vectorization and it is enabled by default, and is disabled or controlled on a per-instance basis with `pragma'`s, so all these declarations will never be supported by MSVC, even if they upgrade OpenMP support, and thus they need to be guarded for that specific compiler.

Performance gains are significant so this needs to be done. When using the existing mkl-dnn code as the back end of `Intel-Caffe`, the default Caffe back end actually out-performs mkl-dnn in my tests (restnet50 forward pass). However, with OpenMP enabled via these changes, it out-performs Caffe's default back end with a ~50% increase in execution speed.