### PR TITLE
Enables OpenMP support in MSVC

### DIFF
--- a/cmake/OpenMP.cmake
+++ b/cmake/OpenMP.cmake
@@ -26,6 +26,7 @@ include("cmake/MKL.cmake")
 
 if(WIN32 AND ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
     add_definitions(/Qpar)
+    add_definitions(/openmp)
 else()
     find_package(OpenMP)
     #newer version for findOpenMP (>= v. 3.9)

--- a/examples/simple_rnn.cpp
+++ b/examples/simple_rnn.cpp
@@ -24,6 +24,11 @@
 
 #include "mkldnn.hpp"
 
+// MSVC doesn't support collapse clause in omp parallel
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define collapse(x)
+#endif
+
 using namespace mkldnn;
 
 const int batch = 128;

--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -31,7 +31,7 @@ inline int omp_in_parallel() { return 0; }
 /* MSVC still supports omp 2.0 only */
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #   ifndef MAX_THREAD
-#	    define MAX_THREAD 64
+#       define MAX_THREAD 64
 #   endif
 
 #	define collapse(x)

--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -21,16 +21,39 @@
 
 #if defined(_OPENMP)
 #include <omp.h>
-#else
-inline int omp_get_max_threads() { return 1; }
-inline int omp_get_num_threads() { return 1; }
-inline int omp_get_thread_num() { return 0; }
-inline int omp_in_parallel() { return 0; }
-#endif
 
 /* VisualStudio still support omp 2.0 */
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#define collapse(x)
+#ifndef MAX_THREAD
+#	define MAX_THREAD 64
+#endif // #ifndef MAX_THREAD
+
+#	define collapse(x)
+
+	// nop that doesn't produce warnings.
+	// PRAGMA_OMP_SIMD(x) will flood 4003
+	// warnings where no arg is supplied
+	// beyond omp simd.
+#	define PRAGMA_OMP_SIMD(...)
+#	define PRAGMA_OMP_SIMD_CLAUSE(...)
+#else
+#	define _PRAGMA_OMP_CONCAT(x) _Pragma(#x)
+#	define PRAGMA_OMP_SIMD() _Pragma("omp simd")
+#	define PRAGMA_OMP_SIMD_CLAUSE(x) _PRAGMA_OMP_CONCAT(omp simd x)
+#endif // defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#else
+inline int omp_get_max_threads() {
+    return 1;
+}
+inline int omp_get_num_threads() {
+    return 1;
+}
+inline int omp_get_thread_num() {
+    return 0;
+}
+inline int omp_in_parallel() {
+    return 0;
+}
 #endif
 
 namespace mkldnn {
@@ -56,8 +79,8 @@ inline void balance211(T n, U team, U tid, T &n_start, T &n_end) {
     n_end += n_start;
 }
 
-}
-}
+} // namespace impl
+} // namespace mkldnn
 
 #endif
 

--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -30,10 +30,6 @@ inline int omp_in_parallel() { return 0; }
 
 /* MSVC still supports omp 2.0 only */
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#   ifndef MAX_THREAD
-#       define MAX_THREAD 64
-#   endif
-
 #	define collapse(x)
 
 	// nop that doesn't produce warnings.

--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -18,6 +18,7 @@
 #define MKLDNN_THREAD_HPP
 
 #include "utils.hpp"
+#include "z_magic.hpp"
 
 #if defined(_OPENMP)
 #include <omp.h>
@@ -39,9 +40,10 @@ inline int omp_in_parallel() { return 0; }
 #	define PRAGMA_OMP_SIMD(...)
 #	define PRAGMA_OMP_SIMD_CLAUSE(...)
 #else
-#	define _PRAGMA_OMP_CONCAT(x) _Pragma(#x)
-#	define PRAGMA_OMP_SIMD() _Pragma("omp simd")
-#	define PRAGMA_OMP_SIMD_CLAUSE(x) _PRAGMA_OMP_CONCAT(omp simd x)
+// #    define _PRAGMA_MACRO(x) _Pragma(#x)
+// #    define PRAGMA_OMP_SIMD() _Pragma("omp simd")
+#	define PRAGMA_OMP_SIMD(...) PRAGMA_MACRO(CHAIN2(omp, simd __VA_ARGS__))
+#	define PRAGMA_OMP_SIMD_CLAUSE(...) PRAGMA_MACRO(CHAIN2(omp, simd __VA_ARGS__))
 #endif // defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 
 namespace mkldnn {

--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -31,19 +31,10 @@ inline int omp_in_parallel() { return 0; }
 
 /* MSVC still supports omp 2.0 only */
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#	define collapse(x)
-
-	// nop that doesn't produce warnings.
-	// PRAGMA_OMP_SIMD(x) will flood 4003
-	// warnings where no arg is supplied
-	// beyond omp simd.
-#	define PRAGMA_OMP_SIMD(...)
-#	define PRAGMA_OMP_SIMD_CLAUSE(...)
+#   define collapse(x)
+#   define PRAGMA_OMP_SIMD(...)
 #else
-// #    define _PRAGMA_MACRO(x) _Pragma(#x)
-// #    define PRAGMA_OMP_SIMD() _Pragma("omp simd")
-#	define PRAGMA_OMP_SIMD(...) PRAGMA_MACRO(CHAIN2(omp, simd __VA_ARGS__))
-#	define PRAGMA_OMP_SIMD_CLAUSE(...) PRAGMA_MACRO(CHAIN2(omp, simd __VA_ARGS__))
+#   define PRAGMA_OMP_SIMD(...) PRAGMA_MACRO(CHAIN2(omp, simd __VA_ARGS__))
 #endif // defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 
 namespace mkldnn {

--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -21,12 +21,18 @@
 
 #if defined(_OPENMP)
 #include <omp.h>
+#else // defined(_OPENMP)
+inline int omp_get_max_threads() { return 1; }
+inline int omp_get_num_threads() { return 1; }
+inline int omp_get_thread_num() { return 0; }
+inline int omp_in_parallel() { return 0; }
+#endif
 
-/* VisualStudio still support omp 2.0 */
+/* MSVC still supports omp 2.0 only */
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#ifndef MAX_THREAD
-#	define MAX_THREAD 64
-#endif // #ifndef MAX_THREAD
+#   ifndef MAX_THREAD
+#	    define MAX_THREAD 64
+#   endif
 
 #	define collapse(x)
 
@@ -41,20 +47,6 @@
 #	define PRAGMA_OMP_SIMD() _Pragma("omp simd")
 #	define PRAGMA_OMP_SIMD_CLAUSE(x) _PRAGMA_OMP_CONCAT(omp simd x)
 #endif // defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#else
-inline int omp_get_max_threads() {
-    return 1;
-}
-inline int omp_get_num_threads() {
-    return 1;
-}
-inline int omp_get_thread_num() {
-    return 0;
-}
-inline int omp_in_parallel() {
-    return 0;
-}
-#endif
 
 namespace mkldnn {
 namespace impl {

--- a/src/common/scratchpad.cpp
+++ b/src/common/scratchpad.cpp
@@ -14,9 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "scratchpad.hpp"
-
 #include "mkldnn_thread.hpp"
+
+#include "scratchpad.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/common/scratchpad.cpp
+++ b/src/common/scratchpad.cpp
@@ -14,6 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "mkldnn_thread.hpp"
+
 #include "scratchpad.hpp"
 
 namespace mkldnn {
@@ -76,15 +78,14 @@ struct global_scratchpad_t : public scratchpad_t {
     }
 
 private:
-    static char *scratchpad_;
-    static size_t size_;
-    static unsigned int reference_count_;
-#pragma omp threadprivate(scratchpad_, size_, reference_count_)
+    thread_local static char *scratchpad_;
+    thread_local static size_t size_;
+    thread_local static unsigned int reference_count_;
 };
 
-char *global_scratchpad_t::scratchpad_ = nullptr;
-size_t global_scratchpad_t::size_ = 0;
-unsigned int global_scratchpad_t::reference_count_ = 0;
+thread_local char *global_scratchpad_t::scratchpad_ = nullptr;
+thread_local size_t global_scratchpad_t::size_ = 0;
+thread_local unsigned int global_scratchpad_t::reference_count_ = 0;
 
 
 /*

--- a/src/common/scratchpad.cpp
+++ b/src/common/scratchpad.cpp
@@ -18,6 +18,13 @@
 
 #include "scratchpad.hpp"
 
+#ifdef __APPLE__
+// older XCode doesn't support thread_local
+#define THREAD_LOCAL __thread
+#else
+#define THREAD_LOCAL thread_local
+#endif
+
 namespace mkldnn {
 namespace impl {
 
@@ -78,14 +85,14 @@ struct global_scratchpad_t : public scratchpad_t {
     }
 
 private:
-    thread_local static char *scratchpad_;
-    thread_local static size_t size_;
-    thread_local static unsigned int reference_count_;
+    THREAD_LOCAL static char *scratchpad_;
+    THREAD_LOCAL static size_t size_;
+    THREAD_LOCAL static unsigned int reference_count_;
 };
 
-thread_local char *global_scratchpad_t::scratchpad_ = nullptr;
-thread_local size_t global_scratchpad_t::size_ = 0;
-thread_local unsigned int global_scratchpad_t::reference_count_ = 0;
+THREAD_LOCAL char *global_scratchpad_t::scratchpad_ = nullptr;
+THREAD_LOCAL size_t global_scratchpad_t::size_ = 0;
+THREAD_LOCAL unsigned int global_scratchpad_t::reference_count_ = 0;
 
 
 /*

--- a/src/common/scratchpad.cpp
+++ b/src/common/scratchpad.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "mkldnn_thread.hpp"
-
 #include "scratchpad.hpp"
 
 namespace mkldnn {
@@ -53,97 +51,41 @@ private:
   scratchpad
 */
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-// MSVC only supports <= OMP 2.0. Declaring static members
-// to be threadprivate is only supported in OMP >= 3.0.
-// As such, we need to implement this ourselves here.
 struct global_scratchpad_t : public scratchpad_t {
-	global_scratchpad_t(size_t size) {
-		int tid = omp_get_thread_num();
-		if (size > tls_[tid].size_) {
-			if (tls_[tid].scratchpad_ != nullptr) free(tls_[tid].scratchpad_);
-			tls_[tid].size_ = size;
-			tls_[tid].scratchpad_ = (char *)malloc(size, page_size);
-			assert(scratchpad_ != nullptr);
-		}
-		tls_[tid].reference_count_++;
-	}
-	~global_scratchpad_t() {
-		int tid = omp_get_thread_num();
-		tls_[tid].reference_count_--;
-		if (tls_[tid].reference_count_ == 0) {
-			free(tls_[tid].scratchpad_);
-			tls_[tid].scratchpad_ = nullptr;
-			tls_[tid].size_ = 0;
-		}
-	}
+    global_scratchpad_t(size_t size) {
+        if (size > size_) {
+            if (scratchpad_ != nullptr) free(scratchpad_);
+            size_ = size;
+            scratchpad_ = (char *) malloc(size, page_size);
+            assert(scratchpad_ != nullptr);
+        }
+        reference_count_++;
+    }
 
-	void* operator new(size_t i)
-	{
-		return _aligned_malloc(i, 64);
-	}
+    ~global_scratchpad_t() {
+        reference_count_--;
+        if (reference_count_ == 0) {
+            free(scratchpad_);
+            scratchpad_ = nullptr;
+            size_ = 0;
+        }
+    }
 
-	void operator delete(void* p)
-	{
-		_aligned_free(p);
-	}
-
-	virtual char *get() const {
-		return tls_[omp_get_thread_num()].scratchpad_;
-	}
+    virtual char *get() const {
+        return scratchpad_;
+    }
 
 private:
-	struct omp_2_fallback_member_tls
-	{
-		static char *scratchpad_;
-		static size_t size_;
-		static unsigned int reference_count_;
-
-		char padding_[64 - (sizeof(scratchpad_) + sizeof(size_) + sizeof(reference_count_))];
-	};
-
-	__declspec(align(64)) omp_2_fallback_member_tls tls_[MAX_THREAD];
-};
-
-char *global_scratchpad_t::omp_2_fallback_member_tls::scratchpad_ = nullptr;
-size_t global_scratchpad_t::omp_2_fallback_member_tls::size_ = 0;
-unsigned int global_scratchpad_t::omp_2_fallback_member_tls::reference_count_ = 0;
-#else
-struct global_scratchpad_t : public scratchpad_t {
-	global_scratchpad_t(size_t size) {
-		if (size > size_) {
-			if (scratchpad_ != nullptr) free(scratchpad_);
-			size_ = size;
-			scratchpad_ = (char *)malloc(size, page_size);
-			assert(scratchpad_ != nullptr);
-		}
-		reference_count_++;
-	}
-
-	~global_scratchpad_t() {
-		reference_count_--;
-		if (reference_count_ == 0) {
-			free(scratchpad_);
-			scratchpad_ = nullptr;
-			size_ = 0;
-		}
-	}
-
-	virtual char *get() const {
-		return scratchpad_;
-	}
-
-private:
-	static char *scratchpad_;
-	static size_t size_;
-	static unsigned int reference_count_;
+    static char *scratchpad_;
+    static size_t size_;
+    static unsigned int reference_count_;
 #pragma omp threadprivate(scratchpad_, size_, reference_count_)
 };
 
 char *global_scratchpad_t::scratchpad_ = nullptr;
 size_t global_scratchpad_t::size_ = 0;
 unsigned int global_scratchpad_t::reference_count_ = 0;
-#endif // #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+
 
 /*
    Scratchpad creation routine

--- a/src/common/z_magic.hpp
+++ b/src/common/z_magic.hpp
@@ -17,11 +17,17 @@
 #ifndef Z_MAGIC_HPP
 #define Z_MAGIC_HPP
 
+#define CHAIn2(a,b) a b
+#define CHAIN2(a,b) CHAIn2(a,b)
+
 #define CONCAt2(a,b) a ## b
 #define CONCAT2(a,b) CONCAt2(a,b)
 
 #define STRINGIFy(s) #s
 #define STRINGIFY(s) STRINGIFy(s)
+
+#define PRAGMA_MACRo(x) _Pragma(#x)
+#define PRAGMA_MACRO(x) PRAGMA_MACRo(x)
 
 #endif
 

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -296,7 +296,7 @@ void _gemm_convolution_bwd_weights_t<run_jit, isa>::execute_backward_weights() {
                     size_t offset = offset_ + mb*jcp.ngroups*dst_step;
                     for (int od = 0; od < jcp.od; ++od)
                     for (int oh = 0; oh < jcp.oh; ++oh)
-                    PRAGMA_OMP_SIMD_CLAUSE(reduction(+:db))
+                    PRAGMA_OMP_SIMD(reduction(+:db))
                     for (int ow = 0; ow < jcp.ow; ++ow)
                     {
                         db += diff_dst[offset];

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -149,9 +149,10 @@ void _gemm_convolution_bwd_data_t<run_jit, isa>::execute_backward_data() {
         data_t *_col = this->col_ + (size_t)ithr * jcp.ic * jcp.ks * jcp.os;
 
         if (jcp.id > 1) {
-        #pragma omp for
-        for (long i = 0; i < jcp.ngroups*jcp.mb*src_step; ++i)
-            diff_src[i] = 0.;
+            ptrdiff_t diff_src_sz = (ptrdiff_t)(work_amount * src_step);
+            #pragma omp for
+            for (ptrdiff_t i = 0; i < diff_src_sz; ++i)
+                diff_src[i] = 0.;
         }
 
         int g{0}, n{0};

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -295,7 +295,7 @@ void _gemm_convolution_bwd_weights_t<run_jit, isa>::execute_backward_weights() {
                     size_t offset = offset_ + mb*jcp.ngroups*dst_step;
                     for (int od = 0; od < jcp.od; ++od)
                     for (int oh = 0; oh < jcp.oh; ++oh)
-PRAGMA_OMP_SIMD_CLAUSE(reduction(+:db))
+                    PRAGMA_OMP_SIMD_CLAUSE(reduction(+:db))
                     for (int ow = 0; ow < jcp.ow; ++ow)
                     {
                         db += diff_dst[offset];

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -150,7 +150,7 @@ void _gemm_convolution_bwd_data_t<run_jit, isa>::execute_backward_data() {
 
         if (jcp.id > 1) {
         #pragma omp for
-        for (size_t i = 0; i < jcp.ngroups*jcp.mb*src_step; ++i)
+        for (long i = 0; i < jcp.ngroups*jcp.mb*src_step; ++i)
             diff_src[i] = 0.;
         }
 
@@ -295,7 +295,7 @@ void _gemm_convolution_bwd_weights_t<run_jit, isa>::execute_backward_weights() {
                     size_t offset = offset_ + mb*jcp.ngroups*dst_step;
                     for (int od = 0; od < jcp.od; ++od)
                     for (int oh = 0; oh < jcp.oh; ++oh)
-#                   pragma omp simd reduction(+:db)
+PRAGMA_OMP_SIMD_CLAUSE(reduction(+:db))
                     for (int ow = 0; ow < jcp.ow; ++ow)
                     {
                         db += diff_dst[offset];

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -223,7 +223,7 @@ void im2col_u8(
                             * jcp.kw + kw) * jcp.ic;
                     const size_t im_idx
                         = (ih * jcp.iw + iw) * jcp.ngroups * jcp.ic;
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int ic = 0; ic < jcp.ic; ++ic) {
                         col[col_idx + ic] = im[im_idx + ic];
                     }
@@ -290,7 +290,7 @@ void col2im(
     for (int ic = 0; ic < jcp.ic; ++ic) {
         float *im_ = im + ic * im_step;
         const float *col_ = col + ic * col_step;
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int is = 0; is < iS; ++is) im_[is] = 0.;
 
         for (int kh = 0; kh < jcp.kh; ++kh) {

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -223,11 +223,7 @@ void im2col_u8(
                             * jcp.kw + kw) * jcp.ic;
                     const size_t im_idx
                         = (ih * jcp.iw + iw) * jcp.ngroups * jcp.ic;
-
-					#ifndef _MSC_VER
-					#pragma omp simd
-					#endif // _MSC_VER
-                    
+PRAGMA_OMP_SIMD()
                     for (int ic = 0; ic < jcp.ic; ++ic) {
                         col[col_idx + ic] = im[im_idx + ic];
                     }
@@ -294,9 +290,7 @@ void col2im(
     for (int ic = 0; ic < jcp.ic; ++ic) {
         float *im_ = im + ic * im_step;
         const float *col_ = col + ic * col_step;
-		#ifndef _MSC_VER
-		#pragma omp simd
-		#endif // _MSC_VER
+PRAGMA_OMP_SIMD()
         for (int is = 0; is < iS; ++is) im_[is] = 0.;
 
         for (int kh = 0; kh < jcp.kh; ++kh) {

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -224,7 +224,10 @@ void im2col_u8(
                     const size_t im_idx
                         = (ih * jcp.iw + iw) * jcp.ngroups * jcp.ic;
 
-#                   pragma omp simd
+					#ifndef _MSC_VER
+					#pragma omp simd
+					#endif // _MSC_VER
+                    
                     for (int ic = 0; ic < jcp.ic; ++ic) {
                         col[col_idx + ic] = im[im_idx + ic];
                     }
@@ -291,7 +294,9 @@ void col2im(
     for (int ic = 0; ic < jcp.ic; ++ic) {
         float *im_ = im + ic * im_step;
         const float *col_ = col + ic * col_step;
-#       pragma omp simd
+		#ifndef _MSC_VER
+		#pragma omp simd
+		#endif // _MSC_VER
         for (int is = 0; is < iS; ++is) im_[is] = 0.;
 
         for (int kh = 0; kh < jcp.kh; ++kh) {
@@ -378,7 +383,8 @@ status_t prepare_ws_col(jit_gemm_conv_conf_t &jcp, src_t **col, const int nthr) 
     if (*col == nullptr) return status::out_of_memory;
 
 #   pragma omp parallel for
-    for (size_t i = 0; i < im2col_sz; ++i) (*col)[i] = (src_t)0;
+    for (long i = 0; i < im2col_sz; ++i)
+        (*col)[i] = (src_t)0;
 
     return status::success;
 }

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -371,13 +371,13 @@ status_t prepare_ws_col(jit_gemm_conv_conf_t &jcp, src_t **col, const int nthr) 
         *col = nullptr;
         return status::success;
     }
-    const size_t im2col_sz_per_thr = jcp.os * jcp.ks * jcp.ic;
-    const size_t im2col_sz = nthr * im2col_sz_per_thr;
+    const ptrdiff_t im2col_sz_per_thr = (ptrdiff_t)jcp.os * jcp.ks * jcp.ic;
+    const ptrdiff_t im2col_sz = nthr * im2col_sz_per_thr;
     *col = (src_t *)malloc(im2col_sz * sizeof(src_t), 64);
     if (*col == nullptr) return status::out_of_memory;
 
 #   pragma omp parallel for
-    for (long i = 0; i < im2col_sz; ++i)
+    for (ptrdiff_t i = 0; i < im2col_sz; ++i)
         (*col)[i] = (src_t)0;
 
     return status::success;

--- a/src/cpu/gemm_inner_product.cpp
+++ b/src/cpu/gemm_inner_product.cpp
@@ -157,13 +157,15 @@ void gemm_inner_product_bwd_weights_t<data_type>::execute_backward_weights() {
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (cblas_int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (cblas_int mb = 1; mb < MB; ++mb) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (cblas_int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/gemm_inner_product.cpp
+++ b/src/cpu/gemm_inner_product.cpp
@@ -157,15 +157,13 @@ void gemm_inner_product_bwd_weights_t<data_type>::execute_backward_weights() {
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (cblas_int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (cblas_int mb = 1; mb < MB; ++mb) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (cblas_int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/jit_avx2_1x1_convolution.cpp
@@ -508,7 +508,8 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights() {
                     for (int o = 0; o < 8; ++o) d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 8;

--- a/src/cpu/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/jit_avx2_1x1_convolution.cpp
@@ -508,8 +508,7 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights() {
                     for (int o = 0; o < 8; ++o) d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 8;

--- a/src/cpu/jit_avx2_convolution.cpp
+++ b/src/cpu/jit_avx2_convolution.cpp
@@ -300,8 +300,7 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights() {
                         d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 8;

--- a/src/cpu/jit_avx2_convolution.cpp
+++ b/src/cpu/jit_avx2_convolution.cpp
@@ -300,7 +300,8 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights() {
                         d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 8;

--- a/src/cpu/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/jit_avx512_common_1x1_convolution.cpp
@@ -759,8 +759,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights()
                         d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int o = 0; o < 16; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 16;

--- a/src/cpu/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/jit_avx512_common_1x1_convolution.cpp
@@ -437,7 +437,7 @@ jit_avx512_common_1x1_convolution_bwd_weights_t ::
             jcp.nthr_mb * jcp.ngroups * jcp.ic * jcp.tr_is;
         tr_src_ = (data_t *)malloc(tr_src_size * sizeof(data_t), 64);
 #       pragma omp parallel for
-        for (size_t i = 0; i < tr_src_size; i++)
+        for (long i = 0; i < tr_src_size; i++)
             tr_src_[i] = 0;
         auto tp = jit_transpose4x16_src_t();
         tp.src_pf0_distance = 4;
@@ -759,7 +759,8 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights()
                         d_bias[o] = 0.;
 
                 for (int hw = 0; hw < jcp.oh * jcp.ow; ++hw) {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int o = 0; o < 16; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += 16;

--- a/src/cpu/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/jit_avx512_common_1x1_convolution.cpp
@@ -433,11 +433,11 @@ jit_avx512_common_1x1_convolution_bwd_weights_t ::
                         jcp.ngroups * jcp.nb_load, jcp.mb, max_buffer_size));
     }
     if (jcp.transpose_src) {
-        const size_t tr_src_size =
-            jcp.nthr_mb * jcp.ngroups * jcp.ic * jcp.tr_is;
+        const ptrdiff_t tr_src_size = (ptrdiff_t)jcp.nthr_mb
+            * (ptrdiff_t)jcp.ngroups * (ptrdiff_t)jcp.ic * jcp.tr_is;
         tr_src_ = (data_t *)malloc(tr_src_size * sizeof(data_t), 64);
 #       pragma omp parallel for
-        for (long i = 0; i < tr_src_size; i++)
+        for (ptrdiff_t i = 0; i < tr_src_size; i++)
             tr_src_[i] = 0;
         auto tp = jit_transpose4x16_src_t();
         tp.src_pf0_distance = 4;

--- a/src/cpu/jit_avx512_common_convolution.cpp
+++ b/src/cpu/jit_avx512_common_convolution.cpp
@@ -806,20 +806,23 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const int tr_iw = jcp.tr_iw;
 
         for (size_t iwork = start; iwork < end; iwork++) {
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
 #           pragma unroll
             for (int i = 0; i < l_pad; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
                     tr_src1[j * jcp.tr_iw + i] = (src_data_t)0.0;
 
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
 #           pragma unroll
             for (int i = l_pad; i < iwlp; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
                     tr_src1[j * jcp.tr_iw + i]
                         = (src_data_t)src1[(i - l_pad) * 16 + j];
 
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
 #           pragma unroll
             for (int i = iwlp; i < tr_iw; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
@@ -1245,7 +1248,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 for (int o = 0; o < 16; ++o)
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int o = 0; o < 16; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += 16;

--- a/src/cpu/jit_avx512_common_convolution.cpp
+++ b/src/cpu/jit_avx512_common_convolution.cpp
@@ -806,23 +806,20 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const int tr_iw = jcp.tr_iw;
 
         for (size_t iwork = start; iwork < end; iwork++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
 #           pragma unroll
             for (int i = 0; i < l_pad; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
                     tr_src1[j * jcp.tr_iw + i] = (src_data_t)0.0;
 
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
 #           pragma unroll
             for (int i = l_pad; i < iwlp; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
                     tr_src1[j * jcp.tr_iw + i]
                         = (src_data_t)src1[(i - l_pad) * 16 + j];
 
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
 #           pragma unroll
             for (int i = iwlp; i < tr_iw; i++)
                 for (int j = 0; j < jcp.ic_block; j++)
@@ -1248,8 +1245,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 for (int o = 0; o < 16; ++o)
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int o = 0; o < 16; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += 16;

--- a/src/cpu/jit_avx512_common_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_common_convolution_winograd.cpp
@@ -46,8 +46,7 @@ void inline load_ps(float *dest, const float *src_mem) {
     __m512 *Iv512 = (__m512 *)dest;
     Iv512[0] = _mm512_load_ps(src_mem);
 #else
-
-PRAGMA_OMP_SIMD()
+    PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++) dest[v] = src_mem[v];
 #endif
 }
@@ -59,8 +58,7 @@ void inline store_output(float *dest, const float *data, bool streamout) {
     else
         _mm512_store_ps(dest, *((__m512 *)data));
 #else
-
-PRAGMA_OMP_SIMD()
+    PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++)
         dest[v] = data[v];
 #endif
@@ -79,18 +77,18 @@ void inline accum_output(
     else
         _mm512_store_ps(dest, _data);
 #else
-
-PRAGMA_OMP_SIMD()
+    PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++)
         data[v] += dest[v];
-    if (with_relu_postsum)
 
-PRAGMA_OMP_SIMD()
+    if (with_relu_postsum) {
+        PRAGMA_OMP_SIMD()
         for (int v = 0; v < simd_w; v++)
             if (data[v] < 0.f)
                 data[v] = 0.f;
+    }
 
-PRAGMA_OMP_SIMD()
+    PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++)
         dest[v] = data[v];
 #endif
@@ -111,8 +109,7 @@ void trans_W_4x4_3x3(float Fw_[6][6][16][16], float F[3][3][16][16]) {
     for (int j = 0; j < 16; j++) {
 #pragma unroll
         for (int i = 0; i < 3; i++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int k = 0; k < 16; k++) {
                 t0[k] = 0.26890756302521f * F[2][i][j][k];
                 t1[k] = -t0[k] - 0.688403361344538f * F[0][i][j][k];
@@ -128,8 +125,7 @@ PRAGMA_OMP_SIMD()
         }
 #pragma unroll
         for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int k = 0; k < 16; k++) {
                 t0[k] = 0.26890756302521f * T[i][2][k];
                 t1[k] = -t0[k] - 0.688403361344538f * T[i][0][k];
@@ -159,8 +155,7 @@ void trans_O_4x4_3x3(float Mw[6][6][16], float O[4][4][16]) {
 
 #pragma unroll
     for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = Mw[1][i][v] + Mw[2][i][v];
             t1[v] = Mw[3][i][v] + Mw[4][i][v];
@@ -175,8 +170,7 @@ PRAGMA_OMP_SIMD()
     }
 #pragma unroll
     for (int i = 0; i < 4; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = T[i][1][v] + T[i][2][v];
             t1[v] = T[i][3][v] + T[i][4][v];
@@ -208,8 +202,7 @@ void trans_W_3x3_4x4(float Fw[6][6][16], float F[4][6][16])
 
 pragma_unroll
     for (int i = 0; i < 4; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < 16; j++) {
             t0[j] = F[2][i][j] * rcp6;
             t1[j] = F[0][i][j] * -rcp6 - t0[j];
@@ -227,8 +220,7 @@ PRAGMA_OMP_SIMD()
     }
 pragma_unroll
     for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < 16; j++) {
             t0[j] = T[i][2][j] * rcp6;
             t1[j] = T[i][0][j] * -rcp6 - t0[j];
@@ -257,8 +249,7 @@ void trans_O_3x3_4x4(float Mw[6][6][16][16], float M[3][3][16][16])
     for (int j = 0; j < 16; j++) {
 pragma_unroll
         for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int l = 0; l < 16; l++) {
                 t0[l] = Mw[1][i][j][l] + Mw[2][i][j][l];
                 t1[l] = Mw[3][i][j][l] + Mw[4][i][j][l];
@@ -272,8 +263,7 @@ PRAGMA_OMP_SIMD()
         }
 pragma_unroll
         for (int i = 0; i < 3; i++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int l = 0; l < 16; l++) {
                 t0[l] = T[i][1][l] + T[i][2][l];
                 t1[l] = T[i][3][l] + T[i][4][l];
@@ -304,8 +294,7 @@ void trans_I_4x4_3x3(float Iw[6][6][16], float I[6][6][16])
 
 pragma_unroll
     for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = I[2][i][v] * -2.25f + I[4][i][v];
             t1[v] = I[1][i][v] * -2.25f + I[3][i][v];
@@ -325,8 +314,7 @@ PRAGMA_OMP_SIMD()
 
 pragma_unroll
     for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = T[i][2][v] * -2.25f + T[i][4][v];
             t1[v] = T[i][1][v] * -2.25f + T[i][3][v];
@@ -356,8 +344,7 @@ void trans_W_3x3_4x4_wu(float Fw[6][6][16], float F[4][6][16])
 
 pragma_unroll
     for (int i = 0; i < 4; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = F[2][i][v] * 0.26890756302521f;
             t1[v] = F[0][i][v] * -0.688403361344538f - t0[v];
@@ -407,8 +394,7 @@ void trans_O_3x3_4x4_wu(float Mw[6][6][16][16], float M[3][3][16][16])
     for (int j = 0; j < 16; j++) {
 pragma_unroll
         for (int i = 0; i < 6; i++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int v = 0; v < 16; v++) {
                 t0[v] = Mw[1][i][j][v] + Mw[2][i][j][v];
                 t1[v] = Mw[3][i][j][v] + Mw[4][i][j][v];
@@ -422,8 +408,7 @@ PRAGMA_OMP_SIMD()
         }
 pragma_unroll
         for (int i = 0; i < 3; i++) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int v = 0; v < 16; v++) {
                 t0[v] = T[i][1][v] + T[i][2][v];
                 t1[v] = T[i][3][v] + T[i][4][v];
@@ -437,8 +422,7 @@ PRAGMA_OMP_SIMD()
 
 pragma_unroll
             for (int k = 0; k < 3; k++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v = 0; v < 16; v++) {
                     M[i][k][j][v] = M_[k][v];
                 }
@@ -487,8 +471,7 @@ void input_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                             float *pinp_i = pinp_j + (xdim - l_pad) * 16;
                             load_ps(I[j][i], pinp_i);
                         } else {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -496,8 +479,7 @@ PRAGMA_OMP_SIMD()
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -572,8 +554,7 @@ void input_transform_tileblock_data(int tile_block,
                             float *pinp_i = pinp_j + (xdim - l_pad) * simd_w;
                             load_ps(I[j][i], pinp_i);
                         } else {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -581,8 +562,7 @@ PRAGMA_OMP_SIMD()
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -630,8 +610,7 @@ void weight_transform_data(const jit_conv_winograd_conf_t &jcp,
                 float *base_inp = is_fwd
                                 ? &(input(0, 0, j, i, v1, 0))
                                 : &(input(0, 0, 2 - j, 2 - i, v1, 0));
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v2 = 0; v2 < simd_w; v2++) {
                     if (is_fwd)
                         F[j][i][v1][v2] = *(base_inp + v2);
@@ -647,8 +626,7 @@ PRAGMA_OMP_SIMD()
     for (int j = 0; j < alpha; j++) {
         for (int i = 0; i < alpha; i++) {
             for (int v1 = 0; v1 < simd_w; v1++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v2 = 0; v2 < simd_w; v2++) {
                     output(0, j, i, 0, 0, 0, v1, v2) = Fw[j][i][v1][v2];
                 }
@@ -686,8 +664,7 @@ void output_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
         for (int ti = 0; ti < jcp.itiles; ti++) {
             for (int j = 0; j < alpha; j++) {
                 for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int v = 0; v < simd_w; v++) {
                         Ow[j][i][v] = input(tile_block, 0,
                                 j, i,
@@ -708,8 +685,7 @@ PRAGMA_OMP_SIMD()
                         if (xdim < outw) {
                             float *pout_i = pout_j + xdim * simd_w;
                             if (is_fwd) {
-
-PRAGMA_OMP_SIMD()
+                                PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     O[j][i][v] += with_bias ? bias[v] : 0.f;
                                     O[j][i][v] = true
@@ -793,8 +769,7 @@ void output_transform_tileblock_data(int tile_block,
                         if (xdim < outw) {
                             float *pout_i = pout_j + xdim * simd_w;
                             if (is_fwd) {
-
-PRAGMA_OMP_SIMD()
+                                PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     O[j][i][v] += with_bias ? bias[v] : 0.f;
                                     O[j][i][v] = true
@@ -858,16 +833,14 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     for (int i = 0; i < alpha; i++) {
                         int xdim = ti * tile_size + i;
                         if ((conv.l_pad <= xdim) && xdim < ifwp) {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input(0, 0,
                                         ydim - conv.t_pad,
                                         xdim - conv.l_pad, v);
                             }
                         } else {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -875,8 +848,7 @@ PRAGMA_OMP_SIMD()
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -890,8 +862,7 @@ PRAGMA_OMP_SIMD()
                     for (int i = 0; i < alpha; i++) {
                         float *Iw_temp_base = &(Iw_trans_temp(j, i,
                                                         tile_4fma, 0));
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             Iw_temp_base[v] = Iw[j][i][v];
                         }
@@ -935,8 +906,7 @@ PRAGMA_OMP_SIMD()
             for (int i = 0; i < alpha; i++) {
                 for (int tb = tile_4fma; tb < conv.tile_4fma; tb++) {
                     float *Iw_temp_base = &(Iw_trans_temp(j, i, tb, 0));
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int v = 0; v < simd_w; v++) {
                         Iw_temp_base[v] = 0;
                     }
@@ -985,20 +955,18 @@ void diff_dst_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                         if (xdim < conv.ow) {
                             float *input_base = &(input(0, 0, ydim, xdim, 0));
 
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input_base[v];
                             }
                             if (with_bias && j < tile_size && i < tile_size) {
-
-PRAGMA_OMP_SIMD()
+                                PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     dbias[v] += input_base[v];
                                 }
                             }
                         } else {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1006,8 +974,7 @@ PRAGMA_OMP_SIMD()
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1060,8 +1027,7 @@ void diff_weights_transform_bwd_weights(jit_conv_winograd_conf_t conv,
     for (int j = 0; j < alpha; j++) {
         for (int i = 0; i < alpha; i++) {
             for (int v = 0; v < conv.ic_simd_block; v++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int k = 0; k < conv.oc_simd_block; k++) {
                     Fw[j][i][v][k] = input(0, 0, j, i, 0, 0, v, k);
                 }
@@ -1454,8 +1420,7 @@ _execute_backward_weights_S_D_G_W()
 
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -1550,8 +1515,7 @@ PRAGMA_OMP_SIMD()
                     float* base_bias_ptr = &(diff_bias(ofm1, 0));
                     float* base_bias_prv_ptr = &(diff_bias_prv(
                                 ithr * jcp.oc + ofm1 * simd_w));
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                         base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                     }
@@ -1609,8 +1573,7 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                     for (int i = 0; i < alpha; i++) {
                         int xdim = ti * tile_size + i;
                         if ((conv.l_pad <= xdim) && xdim < ifwp) {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input(img, 0,
                                     ydim - conv.t_pad,
@@ -1618,8 +1581,7 @@ PRAGMA_OMP_SIMD()
                             }
                         }
                         else {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1628,8 +1590,7 @@ PRAGMA_OMP_SIMD()
                 }
                 else {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1642,8 +1603,7 @@ PRAGMA_OMP_SIMD()
             if (ver_4fma) {
                 for (int j = 0; j < alpha; j++) {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             Iw_scratchpad(j, i, tile_4fma, v) = Iw[j][i][v];
                         }
@@ -1707,21 +1667,19 @@ void diff_dst_transform_bwd_weights_tile(int tile_block,
                         if (xdim < conv.ow) {
                             float *input_base = &input(img, 0, ydim, xdim, 0);
 
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input_base[v];
                             }
                             if (with_bias && j < tile_size && i < tile_size) {
-
-PRAGMA_OMP_SIMD()
+                                PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     dbias[v] += input_base[v];
                                 }
                             }
                         }
                         else {
-
-PRAGMA_OMP_SIMD()
+                            PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1730,8 +1688,7 @@ PRAGMA_OMP_SIMD()
                 }
                 else {
                     for (int i = 0; i < alpha; i++) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1773,15 +1730,13 @@ void array_sum(int num_arrs, float *output,
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
             if (!reduce_to_first) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (int a = 1; a < num_arrs; a++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1792,15 +1747,13 @@ PRAGMA_OMP_SIMD()
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
             if (!reduce_to_first) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (int a = 1; a < num_arrs; a++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1830,17 +1783,17 @@ void subarray_sum(int num_arrs, float *output, size_t nelems,
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
@@ -1848,7 +1801,7 @@ PRAGMA_OMP_SIMD()
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
 
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1861,17 +1814,17 @@ PRAGMA_OMP_SIMD()
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
@@ -1879,7 +1832,7 @@ PRAGMA_OMP_SIMD()
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
 
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1958,8 +1911,7 @@ _execute_backward_weights_S_D_Giot_W()
             }
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -2083,8 +2035,7 @@ PRAGMA_OMP_SIMD()
                 float* base_bias_ptr = &(diff_bias(ofm1, 0));
                 float* base_bias_prv_ptr = &(diff_bias_prv(
                             ithr * jcp.oc + ofm1 * simd_w));
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                     base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                 }
@@ -2150,8 +2101,7 @@ _execute_backward_weights_SDGtWo()
                 }
 #pragma omp for nowait
                 for (int bofm = 0; bofm < jcp.oc_block; bofm++) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int v = 0; v < simd_w; v++)
                         diff_bias(ofm1, bofm, v) = 0.0f;
                 }
@@ -2233,8 +2183,7 @@ PRAGMA_OMP_SIMD()
                     float* base_bias_ptr = &(diff_bias(ofm1, ofm2, 0));
                     float* base_bias_prv_ptr = &(diff_bias_prv(
                                 ithr * jcp.oc_block * simd_w + ofm2 * simd_w));
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int ofm3 = 0; ofm3 < simd_w; ofm3++) {
                         base_bias_ptr[ofm3] += base_bias_prv_ptr[ofm3];
                     }
@@ -2303,8 +2252,7 @@ _execute_backward_weights_SDGt_W()
             }
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -2397,8 +2345,7 @@ PRAGMA_OMP_SIMD()
                 float* base_bias_ptr = &(diff_bias(ofm1, 0));
                 float* base_bias_prv_ptr = &(diff_bias_prv(
                             ithr * jcp.oc + ofm1 * simd_w));
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                     base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                 }

--- a/src/cpu/jit_avx512_common_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_common_convolution_winograd.cpp
@@ -46,7 +46,8 @@ void inline load_ps(float *dest, const float *src_mem) {
     __m512 *Iv512 = (__m512 *)dest;
     Iv512[0] = _mm512_load_ps(src_mem);
 #else
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++) dest[v] = src_mem[v];
 #endif
 }
@@ -58,7 +59,8 @@ void inline store_output(float *dest, const float *data, bool streamout) {
     else
         _mm512_store_ps(dest, *((__m512 *)data));
 #else
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++)
         dest[v] = data[v];
 #endif
@@ -77,15 +79,18 @@ void inline accum_output(
     else
         _mm512_store_ps(dest, _data);
 #else
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++)
         data[v] += dest[v];
     if (with_relu_postsum)
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int v = 0; v < simd_w; v++)
             if (data[v] < 0.f)
                 data[v] = 0.f;
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
     for (int v = 0; v < simd_w; v++)
         dest[v] = data[v];
 #endif
@@ -106,7 +111,8 @@ void trans_W_4x4_3x3(float Fw_[6][6][16][16], float F[3][3][16][16]) {
     for (int j = 0; j < 16; j++) {
 #pragma unroll
         for (int i = 0; i < 3; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int k = 0; k < 16; k++) {
                 t0[k] = 0.26890756302521f * F[2][i][j][k];
                 t1[k] = -t0[k] - 0.688403361344538f * F[0][i][j][k];
@@ -122,7 +128,8 @@ void trans_W_4x4_3x3(float Fw_[6][6][16][16], float F[3][3][16][16]) {
         }
 #pragma unroll
         for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int k = 0; k < 16; k++) {
                 t0[k] = 0.26890756302521f * T[i][2][k];
                 t1[k] = -t0[k] - 0.688403361344538f * T[i][0][k];
@@ -152,7 +159,8 @@ void trans_O_4x4_3x3(float Mw[6][6][16], float O[4][4][16]) {
 
 #pragma unroll
     for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = Mw[1][i][v] + Mw[2][i][v];
             t1[v] = Mw[3][i][v] + Mw[4][i][v];
@@ -167,7 +175,8 @@ void trans_O_4x4_3x3(float Mw[6][6][16], float O[4][4][16]) {
     }
 #pragma unroll
     for (int i = 0; i < 4; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = T[i][1][v] + T[i][2][v];
             t1[v] = T[i][3][v] + T[i][4][v];
@@ -199,7 +208,8 @@ void trans_W_3x3_4x4(float Fw[6][6][16], float F[4][6][16])
 
 pragma_unroll
     for (int i = 0; i < 4; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int j = 0; j < 16; j++) {
             t0[j] = F[2][i][j] * rcp6;
             t1[j] = F[0][i][j] * -rcp6 - t0[j];
@@ -217,7 +227,8 @@ pragma_unroll
     }
 pragma_unroll
     for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int j = 0; j < 16; j++) {
             t0[j] = T[i][2][j] * rcp6;
             t1[j] = T[i][0][j] * -rcp6 - t0[j];
@@ -246,7 +257,8 @@ void trans_O_3x3_4x4(float Mw[6][6][16][16], float M[3][3][16][16])
     for (int j = 0; j < 16; j++) {
 pragma_unroll
         for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int l = 0; l < 16; l++) {
                 t0[l] = Mw[1][i][j][l] + Mw[2][i][j][l];
                 t1[l] = Mw[3][i][j][l] + Mw[4][i][j][l];
@@ -260,7 +272,8 @@ pragma_unroll
         }
 pragma_unroll
         for (int i = 0; i < 3; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int l = 0; l < 16; l++) {
                 t0[l] = T[i][1][l] + T[i][2][l];
                 t1[l] = T[i][3][l] + T[i][4][l];
@@ -291,7 +304,8 @@ void trans_I_4x4_3x3(float Iw[6][6][16], float I[6][6][16])
 
 pragma_unroll
     for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = I[2][i][v] * -2.25f + I[4][i][v];
             t1[v] = I[1][i][v] * -2.25f + I[3][i][v];
@@ -311,7 +325,8 @@ pragma_unroll
 
 pragma_unroll
     for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = T[i][2][v] * -2.25f + T[i][4][v];
             t1[v] = T[i][1][v] * -2.25f + T[i][3][v];
@@ -341,7 +356,8 @@ void trans_W_3x3_4x4_wu(float Fw[6][6][16], float F[4][6][16])
 
 pragma_unroll
     for (int i = 0; i < 4; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int v = 0; v < 16; v++) {
             t0[v] = F[2][i][v] * 0.26890756302521f;
             t1[v] = F[0][i][v] * -0.688403361344538f - t0[v];
@@ -391,7 +407,8 @@ void trans_O_3x3_4x4_wu(float Mw[6][6][16][16], float M[3][3][16][16])
     for (int j = 0; j < 16; j++) {
 pragma_unroll
         for (int i = 0; i < 6; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int v = 0; v < 16; v++) {
                 t0[v] = Mw[1][i][j][v] + Mw[2][i][j][v];
                 t1[v] = Mw[3][i][j][v] + Mw[4][i][j][v];
@@ -405,7 +422,8 @@ pragma_unroll
         }
 pragma_unroll
         for (int i = 0; i < 3; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int v = 0; v < 16; v++) {
                 t0[v] = T[i][1][v] + T[i][2][v];
                 t1[v] = T[i][3][v] + T[i][4][v];
@@ -419,7 +437,8 @@ pragma_unroll
 
 pragma_unroll
             for (int k = 0; k < 3; k++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v = 0; v < 16; v++) {
                     M[i][k][j][v] = M_[k][v];
                 }
@@ -468,7 +487,8 @@ void input_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                             float *pinp_i = pinp_j + (xdim - l_pad) * 16;
                             load_ps(I[j][i], pinp_i);
                         } else {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -476,7 +496,8 @@ void input_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -551,7 +572,8 @@ void input_transform_tileblock_data(int tile_block,
                             float *pinp_i = pinp_j + (xdim - l_pad) * simd_w;
                             load_ps(I[j][i], pinp_i);
                         } else {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -559,7 +581,8 @@ void input_transform_tileblock_data(int tile_block,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -607,7 +630,8 @@ void weight_transform_data(const jit_conv_winograd_conf_t &jcp,
                 float *base_inp = is_fwd
                                 ? &(input(0, 0, j, i, v1, 0))
                                 : &(input(0, 0, 2 - j, 2 - i, v1, 0));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v2 = 0; v2 < simd_w; v2++) {
                     if (is_fwd)
                         F[j][i][v1][v2] = *(base_inp + v2);
@@ -623,7 +647,8 @@ void weight_transform_data(const jit_conv_winograd_conf_t &jcp,
     for (int j = 0; j < alpha; j++) {
         for (int i = 0; i < alpha; i++) {
             for (int v1 = 0; v1 < simd_w; v1++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v2 = 0; v2 < simd_w; v2++) {
                     output(0, j, i, 0, 0, 0, v1, v2) = Fw[j][i][v1][v2];
                 }
@@ -661,7 +686,8 @@ void output_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
         for (int ti = 0; ti < jcp.itiles; ti++) {
             for (int j = 0; j < alpha; j++) {
                 for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int v = 0; v < simd_w; v++) {
                         Ow[j][i][v] = input(tile_block, 0,
                                 j, i,
@@ -682,7 +708,8 @@ void output_transform_data(int image, const jit_conv_winograd_conf_t &jcp,
                         if (xdim < outw) {
                             float *pout_i = pout_j + xdim * simd_w;
                             if (is_fwd) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     O[j][i][v] += with_bias ? bias[v] : 0.f;
                                     O[j][i][v] = true
@@ -766,7 +793,8 @@ void output_transform_tileblock_data(int tile_block,
                         if (xdim < outw) {
                             float *pout_i = pout_j + xdim * simd_w;
                             if (is_fwd) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     O[j][i][v] += with_bias ? bias[v] : 0.f;
                                     O[j][i][v] = true
@@ -830,14 +858,16 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     for (int i = 0; i < alpha; i++) {
                         int xdim = ti * tile_size + i;
                         if ((conv.l_pad <= xdim) && xdim < ifwp) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input(0, 0,
                                         ydim - conv.t_pad,
                                         xdim - conv.l_pad, v);
                             }
                         } else {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -845,7 +875,8 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -859,7 +890,8 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     for (int i = 0; i < alpha; i++) {
                         float *Iw_temp_base = &(Iw_trans_temp(j, i,
                                                         tile_4fma, 0));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             Iw_temp_base[v] = Iw[j][i][v];
                         }
@@ -903,7 +935,8 @@ void diff_src_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
             for (int i = 0; i < alpha; i++) {
                 for (int tb = tile_4fma; tb < conv.tile_4fma; tb++) {
                     float *Iw_temp_base = &(Iw_trans_temp(j, i, tb, 0));
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int v = 0; v < simd_w; v++) {
                         Iw_temp_base[v] = 0;
                     }
@@ -951,18 +984,21 @@ void diff_dst_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                         int xdim = ti * tile_size + i;
                         if (xdim < conv.ow) {
                             float *input_base = &(input(0, 0, ydim, xdim, 0));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input_base[v];
                             }
                             if (with_bias && j < tile_size && i < tile_size) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     dbias[v] += input_base[v];
                                 }
                             }
                         } else {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -970,7 +1006,8 @@ void diff_dst_transform_bwd_weights(int image, jit_conv_winograd_conf_t conv,
                     }
                 } else {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1023,7 +1060,8 @@ void diff_weights_transform_bwd_weights(jit_conv_winograd_conf_t conv,
     for (int j = 0; j < alpha; j++) {
         for (int i = 0; i < alpha; i++) {
             for (int v = 0; v < conv.ic_simd_block; v++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int k = 0; k < conv.oc_simd_block; k++) {
                     Fw[j][i][v][k] = input(0, 0, j, i, 0, 0, v, k);
                 }
@@ -1416,7 +1454,8 @@ _execute_backward_weights_S_D_G_W()
 
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -1511,7 +1550,8 @@ _execute_backward_weights_S_D_G_W()
                     float* base_bias_ptr = &(diff_bias(ofm1, 0));
                     float* base_bias_prv_ptr = &(diff_bias_prv(
                                 ithr * jcp.oc + ofm1 * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                         base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                     }
@@ -1569,7 +1609,8 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                     for (int i = 0; i < alpha; i++) {
                         int xdim = ti * tile_size + i;
                         if ((conv.l_pad <= xdim) && xdim < ifwp) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input(img, 0,
                                     ydim - conv.t_pad,
@@ -1577,7 +1618,8 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                             }
                         }
                         else {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1586,7 +1628,8 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
                 }
                 else {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1599,7 +1642,8 @@ void diff_src_transform_bwd_weights_tile(int tile_block,
             if (ver_4fma) {
                 for (int j = 0; j < alpha; j++) {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             Iw_scratchpad(j, i, tile_4fma, v) = Iw[j][i][v];
                         }
@@ -1662,19 +1706,22 @@ void diff_dst_transform_bwd_weights_tile(int tile_block,
                         int xdim = ti * tile_size + i;
                         if (xdim < conv.ow) {
                             float *input_base = &input(img, 0, ydim, xdim, 0);
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = input_base[v];
                             }
                             if (with_bias && j < tile_size && i < tile_size) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                                 for (int v = 0; v < simd_w; v++) {
                                     dbias[v] += input_base[v];
                                 }
                             }
                         }
                         else {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                             for (int v = 0; v < simd_w; v++) {
                                 I[j][i][v] = 0.0f;
                             }
@@ -1683,7 +1730,8 @@ void diff_dst_transform_bwd_weights_tile(int tile_block,
                 }
                 else {
                     for (int i = 0; i < alpha; i++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int v = 0; v < simd_w; v++) {
                             I[j][i][v] = 0.0f;
                         }
@@ -1725,13 +1773,15 @@ void array_sum(int num_arrs, float *output,
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
             if (!reduce_to_first) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1742,13 +1792,15 @@ void array_sum(int num_arrs, float *output,
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
             if (!reduce_to_first) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1777,22 +1829,26 @@ void subarray_sum(int num_arrs, float *output, size_t nelems,
             size_t end_e = start_e + block_size;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (int a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1804,22 +1860,26 @@ void subarray_sum(int num_arrs, float *output, size_t nelems,
             size_t end_e = nelems;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (int a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -1898,7 +1958,8 @@ _execute_backward_weights_S_D_Giot_W()
             }
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -2022,7 +2083,8 @@ _execute_backward_weights_S_D_Giot_W()
                 float* base_bias_ptr = &(diff_bias(ofm1, 0));
                 float* base_bias_prv_ptr = &(diff_bias_prv(
                             ithr * jcp.oc + ofm1 * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                     base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                 }
@@ -2088,7 +2150,8 @@ _execute_backward_weights_SDGtWo()
                 }
 #pragma omp for nowait
                 for (int bofm = 0; bofm < jcp.oc_block; bofm++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int v = 0; v < simd_w; v++)
                         diff_bias(ofm1, bofm, v) = 0.0f;
                 }
@@ -2170,7 +2233,8 @@ _execute_backward_weights_SDGtWo()
                     float* base_bias_ptr = &(diff_bias(ofm1, ofm2, 0));
                     float* base_bias_prv_ptr = &(diff_bias_prv(
                                 ithr * jcp.oc_block * simd_w + ofm2 * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int ofm3 = 0; ofm3 < simd_w; ofm3++) {
                         base_bias_ptr[ofm3] += base_bias_prv_ptr[ofm3];
                     }
@@ -2239,7 +2303,8 @@ _execute_backward_weights_SDGt_W()
             }
 #pragma omp for nowait
             for (int bofm = 0; bofm < jcp.oc / simd_w; bofm++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++)
                     diff_bias(bofm, v) = 0.0f;
             }
@@ -2332,7 +2397,8 @@ _execute_backward_weights_SDGt_W()
                 float* base_bias_ptr = &(diff_bias(ofm1, 0));
                 float* base_bias_prv_ptr = &(diff_bias_prv(
                             ithr * jcp.oc + ofm1 * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int ofm2 = 0; ofm2 < simd_w; ofm2++) {
                     base_bias_ptr[ofm2] += base_bias_prv_ptr[ofm2];
                 }

--- a/src/cpu/jit_avx512_core_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_core_convolution_winograd.cpp
@@ -554,22 +554,26 @@ void subarray_sum(size_t num_arrs, float *output, size_t nelems,
             size_t end_e = start_e + block_size;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (size_t a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -581,22 +585,26 @@ void subarray_sum(size_t num_arrs, float *output, size_t nelems,
             size_t end_e = nelems;
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
             for (size_t a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -625,13 +633,15 @@ void array_sum(size_t num_arrs, float *output,
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
             if (!reduce_to_first) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (size_t a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -642,13 +652,15 @@ void array_sum(size_t num_arrs, float *output,
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
             if (!reduce_to_first) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (size_t a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -719,7 +731,8 @@ _execute_backward_weights_SDGtWo() {
         for (int ithr = 0; ithr < nthreads; ithr++) {
             for (int ofm = 0; ofm < jcp.oc / simd_w; ofm++) {
                 float *pdbias = &(diff_bias_prv(ithr, ofm * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++) {
                     pdbias[v] = 0.0f;
                 }
@@ -1021,13 +1034,15 @@ _execute_backward_weights_S_D_Giot_W() {
         for (int ofm1 = 0; ofm1 < jcp.oc / simd_w; ++ofm1) {
             float* pbias = &(diff_bias(ofm1 * simd_w));
             float *pbias_prv = &(diff_bias_prv(0, ofm1 * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int ofm2 = 0; ofm2 < simd_w; ++ofm2) {
                 pbias[ofm2] = pbias_prv[ofm2];
             }
             for (int ithr = 1; ithr < nthreads; ++ithr) {
                 pbias_prv = &(diff_bias_prv(ithr, ofm1 * simd_w));
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int ofm2 = 0; ofm2 < simd_w; ++ofm2) {
                     pbias[ofm2] += pbias_prv[ofm2];
                 }

--- a/src/cpu/jit_avx512_core_convolution_winograd.cpp
+++ b/src/cpu/jit_avx512_core_convolution_winograd.cpp
@@ -555,25 +555,26 @@ void subarray_sum(size_t num_arrs, float *output, size_t nelems,
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
+
             for (size_t a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
 
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -586,25 +587,26 @@ PRAGMA_OMP_SIMD()
             size_t input_start = max(start_e, min(input_starts[0], end_e));
             size_t input_end = max(start_e, min(input_ends[0], end_e));
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < input_start; e++) {
                 output[e] = 0.f;
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_start; e < input_end; e++) {
                 output[e] = input_ptrs[0][e];
             }
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = input_end; e < end_e; e++) {
                 output[e] = 0.f;
             }
+
             for (size_t a = 1; a < num_arrs; a++) {
                 input_start = max(start_e, input_starts[a]);
                 input_end = min(input_ends[a], end_e);
 
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = input_start; e < input_end; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -633,15 +635,13 @@ void array_sum(size_t num_arrs, float *output,
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
             if (!reduce_to_first) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (size_t a = 1; a < num_arrs; a++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -652,15 +652,13 @@ PRAGMA_OMP_SIMD()
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
             if (!reduce_to_first) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] = input_ptrs[0][e];
                 }
             }
             for (size_t a = 1; a < num_arrs; a++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += input_ptrs[a][e];
                 }
@@ -731,8 +729,7 @@ _execute_backward_weights_SDGtWo() {
         for (int ithr = 0; ithr < nthreads; ithr++) {
             for (int ofm = 0; ofm < jcp.oc / simd_w; ofm++) {
                 float *pdbias = &(diff_bias_prv(ithr, ofm * simd_w));
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int v = 0; v < simd_w; v++) {
                     pdbias[v] = 0.0f;
                 }
@@ -1035,14 +1032,14 @@ _execute_backward_weights_S_D_Giot_W() {
             float* pbias = &(diff_bias(ofm1 * simd_w));
             float *pbias_prv = &(diff_bias_prv(0, ofm1 * simd_w));
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int ofm2 = 0; ofm2 < simd_w; ++ofm2) {
                 pbias[ofm2] = pbias_prv[ofm2];
             }
+
             for (int ithr = 1; ithr < nthreads; ++ithr) {
                 pbias_prv = &(diff_bias_prv(ithr, ofm1 * simd_w));
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int ofm2 = 0; ofm2 < simd_w; ++ofm2) {
                     pbias[ofm2] += pbias_prv[ofm2];
                 }

--- a/src/cpu/jit_uni_inner_product.cpp
+++ b/src/cpu/jit_uni_inner_product.cpp
@@ -114,13 +114,15 @@ void jit_uni_inner_product_bwd_weights_t<isa>::execute_backward_weights()
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (int mb = 1; mb < MB; ++mb) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/jit_uni_inner_product.cpp
+++ b/src/cpu/jit_uni_inner_product.cpp
@@ -114,15 +114,13 @@ void jit_uni_inner_product_bwd_weights_t<isa>::execute_backward_weights()
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (int mb = 1; mb < MB; ++mb) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/jit_uni_pooling.cpp
+++ b/src/cpu/jit_uni_pooling.cpp
@@ -254,13 +254,14 @@ void jit_uni_pooling_bwd_t<isa>::execute_backward_3d() {
             }
         }
     } else {
-        ptrdiff_t nelems = jpp.mb * jpp.c * jpp.id * jpp.ih * jpp.iw;
-		#pragma omp parallel for
+        ptrdiff_t nelems = (ptrdiff_t)jpp.mb * (ptrdiff_t)jpp.c
+            * (ptrdiff_t)jpp.id * (ptrdiff_t)jpp.ih * (ptrdiff_t)jpp.iw;
+#       pragma omp parallel for
         for (ptrdiff_t i = 0; i < nelems; ++i)
             diff_src[i] = 0.;
 
         for (int kd = 0; kd < jpp.kd; ++kd) {
-		#pragma omp parallel for collapse(3) schedule(static)
+#       pragma omp parallel for collapse(3) schedule(static)
         for (int n = 0; n < jpp.mb; ++n) {
             for (int b_c = 0; b_c < jpp.nb_c; ++b_c) {
                 for (int od = 0; od < jpp.od; ++od) {

--- a/src/cpu/jit_uni_pooling.cpp
+++ b/src/cpu/jit_uni_pooling.cpp
@@ -254,13 +254,13 @@ void jit_uni_pooling_bwd_t<isa>::execute_backward_3d() {
             }
         }
     } else {
-        size_t nelems = jpp.mb * jpp.c * jpp.id * jpp.ih * jpp.iw;
-#       pragma omp parallel for
-        for (size_t i = 0; i < nelems; ++i)
+        ptrdiff_t nelems = jpp.mb * jpp.c * jpp.id * jpp.ih * jpp.iw;
+		#pragma omp parallel for
+        for (ptrdiff_t i = 0; i < nelems; ++i)
             diff_src[i] = 0.;
 
         for (int kd = 0; kd < jpp.kd; ++kd) {
-#       pragma omp parallel for collapse(3) schedule(static)
+		#pragma omp parallel for collapse(3) schedule(static)
         for (int n = 0; n < jpp.mb; ++n) {
             for (int b_c = 0; b_c < jpp.nb_c; ++b_c) {
                 for (int od = 0; od < jpp.od; ++od) {

--- a/src/cpu/jit_uni_reorder.cpp
+++ b/src/cpu/jit_uni_reorder.cpp
@@ -569,9 +569,8 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_1d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
-        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[0].n);
-		#pragma omp parallel for
-        for (ptrdiff_t d0 = 0; d0 < nslen; ++d0) {
+#       pragma omp parallel for
+        for (ptrdiff_t d0 = 0; d0 < (ptrdiff_t)ns[0].n; ++d0) {
             auto c = tr::call_param_t();
             c.in = in + d0 * ns[0].is;
             c.out = out + d0 * ns[0].os;
@@ -583,10 +582,9 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_2d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
-        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[1].n);
-		#pragma omp parallel for collapse(2)
-        for (ptrdiff_t d1 = 0; d1 < nslen; ++d1) {
-            for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
+#       pragma omp parallel for collapse(2)
+        for (ptrdiff_t d1 = 0; d1 < (ptrdiff_t)ns[1].n; ++d1) {
+        for (ptrdiff_t d0 = 0; d0 < (ptrdiff_t)ns[0].n; ++d0) {
             auto c = tr::call_param_t();
             c.in = in + d0 * ns[0].is + d1 * ns[1].is;
             c.out = out + d0 * ns[0].os + d1 * ns[1].os;
@@ -599,11 +597,10 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_3d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
-        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[2].n);
 #       pragma omp parallel for collapse(3)
-        for (ptrdiff_t d2 = 0; d2 < nslen; ++d2) {
-        for (size_t d1 = 0; d1 < ns[1].n; ++d1) {
-        for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
+        for (ptrdiff_t d2 = 0; d2 < (ptrdiff_t)ns[2].n; ++d2) {
+        for (ptrdiff_t d1 = 0; d1 < (ptrdiff_t)ns[1].n; ++d1) {
+        for (ptrdiff_t d0 = 0; d0 < (ptrdiff_t)ns[0].n; ++d0) {
             auto c = tr::call_param_t();
             c.in = in + d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is;
             c.out = out + d0 * ns[0].os + d1 * ns[1].os + d2 * ns[2].os;
@@ -617,12 +614,11 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_4d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
-        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[3].n);
 #       pragma omp parallel for collapse(4)
-        for (ptrdiff_t d3 = 0; d3 < nslen; ++d3) {
-        for (size_t d2 = 0; d2 < ns[2].n; ++d2) {
-        for (size_t d1 = 0; d1 < ns[1].n; ++d1) {
-        for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
+        for (ptrdiff_t d3 = 0; d3 < (ptrdiff_t)ns[3].n; ++d3) {
+        for (ptrdiff_t d2 = 0; d2 < (ptrdiff_t)ns[2].n; ++d2) {
+        for (ptrdiff_t d1 = 0; d1 < (ptrdiff_t)ns[1].n; ++d1) {
+        for (ptrdiff_t d0 = 0; d0 < (ptrdiff_t)ns[0].n; ++d0) {
             auto c = tr::call_param_t();
             c.in = in + d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is
                 + d3 * ns[3].is;

--- a/src/cpu/jit_uni_reorder.cpp
+++ b/src/cpu/jit_uni_reorder.cpp
@@ -569,8 +569,9 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_1d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
-#       pragma omp parallel for
-        for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
+        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[0].n);
+		#pragma omp parallel for
+        for (ptrdiff_t d0 = 0; d0 < nslen; ++d0) {
             auto c = tr::call_param_t();
             c.in = in + d0 * ns[0].is;
             c.out = out + d0 * ns[0].os;
@@ -582,9 +583,10 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_2d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
-#       pragma omp parallel for collapse(2)
-        for (size_t d1 = 0; d1 < ns[1].n; ++d1) {
-        for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
+        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[1].n);
+		#pragma omp parallel for collapse(2)
+        for (ptrdiff_t d1 = 0; d1 < nslen; ++d1) {
+            for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
             auto c = tr::call_param_t();
             c.in = in + d0 * ns[0].is + d1 * ns[1].is;
             c.out = out + d0 * ns[0].os + d1 * ns[1].os;
@@ -597,8 +599,9 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_3d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
+        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[2].n);
 #       pragma omp parallel for collapse(3)
-        for (size_t d2 = 0; d2 < ns[2].n; ++d2) {
+        for (ptrdiff_t d2 = 0; d2 < nslen; ++d2) {
         for (size_t d1 = 0; d1 < ns[1].n; ++d1) {
         for (size_t d0 = 0; d0 < ns[0].n; ++d0) {
             auto c = tr::call_param_t();
@@ -614,8 +617,9 @@ struct jit_uni_reorder_t : public cpu_primitive_t {
     void omp_driver_4d(int off, const float *in, float *out,
             const float *scales) {
         tr::node_t *ns = conf_.prb_.nodes + off;
+        ptrdiff_t nslen = static_cast<ptrdiff_t>(ns[3].n);
 #       pragma omp parallel for collapse(4)
-        for (size_t d3 = 0; d3 < ns[3].n; ++d3) {
+        for (ptrdiff_t d3 = 0; d3 < nslen; ++d3) {
         for (size_t d2 = 0; d2 < ns[2].n; ++d2) {
         for (size_t d1 = 0; d1 < ns[1].n; ++d1) {
         for (size_t d0 = 0; d0 < ns[0].n; ++d0) {

--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -24,6 +24,8 @@
 
 #include "nchw_pooling.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -20,11 +20,10 @@
 #include "c_types_map.hpp"
 #include "type_helpers.hpp"
 #include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
 #include "nstl.hpp"
 
 #include "nchw_pooling.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ncsp_batch_normalization.cpp
+++ b/src/cpu/ncsp_batch_normalization.cpp
@@ -131,8 +131,7 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = (c + C_off) * SP;
                     data_t sum = 0;
                     for (int n = N_s; n < N_e; ++n)
-
-PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
+                        PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
                         for (int sp = S_s; sp < S_e; ++sp) {
                             sum += src[off + n * C * SP + sp];
                         }
@@ -150,8 +149,7 @@ PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
                     size_t off = c + C_off;
                     data_t sum = 0.;
                     for (int n = N_s; n < N_e; ++n)
-
-PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
+                        PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
                         for (int sp = S_s; sp < S_e; ++sp) {
                             data_t m = src[off * SP + n * C * SP + sp]
                                     - mean[off];
@@ -175,8 +173,7 @@ PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
                 data_t sqrt_variance
                         = static_cast<data_t>(1.0f / sqrtf(variance[off] + eps));
                 for (int n = N_s; n < N_e; ++n)
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int sp = S_s; sp < S_e; ++sp) {
                         size_t d_off = off * SP + n * C * SP + sp;
                         data_t bn_res
@@ -278,8 +275,7 @@ void ncsp_batch_normalization_bwd_t::execute_backward() {
                 data_t diff_gamma = 0.0, diff_beta = 0.0;
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
-
-PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : diff_gamma, diff_beta))
+                    PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : diff_gamma, diff_beta))
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         data_t dd;
@@ -316,8 +312,7 @@ PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : diff_gamma, diff_beta))
                         = static_cast<data_t>(1.0f / sqrtf(variance[off] + eps));
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         ;

--- a/src/cpu/ncsp_batch_normalization.cpp
+++ b/src/cpu/ncsp_batch_normalization.cpp
@@ -131,7 +131,8 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = (c + C_off) * SP;
                     data_t sum = 0;
                     for (int n = N_s; n < N_e; ++n)
-#pragma omp simd reduction(+ : sum)
+
+PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
                         for (int sp = S_s; sp < S_e; ++sp) {
                             sum += src[off + n * C * SP + sp];
                         }
@@ -149,7 +150,8 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = c + C_off;
                     data_t sum = 0.;
                     for (int n = N_s; n < N_e; ++n)
-#pragma omp simd reduction(+ : sum)
+
+PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
                         for (int sp = S_s; sp < S_e; ++sp) {
                             data_t m = src[off * SP + n * C * SP + sp]
                                     - mean[off];
@@ -173,7 +175,8 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                 data_t sqrt_variance
                         = static_cast<data_t>(1.0f / sqrtf(variance[off] + eps));
                 for (int n = N_s; n < N_e; ++n)
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int sp = S_s; sp < S_e; ++sp) {
                         size_t d_off = off * SP + n * C * SP + sp;
                         data_t bn_res
@@ -275,7 +278,8 @@ void ncsp_batch_normalization_bwd_t::execute_backward() {
                 data_t diff_gamma = 0.0, diff_beta = 0.0;
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
-#pragma omp simd reduction(+ : diff_gamma, diff_beta)
+
+PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : diff_gamma, diff_beta))
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         data_t dd;
@@ -312,7 +316,8 @@ void ncsp_batch_normalization_bwd_t::execute_backward() {
                         = static_cast<data_t>(1.0f / sqrtf(variance[off] + eps));
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         ;

--- a/src/cpu/ncsp_batch_normalization.cpp
+++ b/src/cpu/ncsp_batch_normalization.cpp
@@ -131,7 +131,7 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = (c + C_off) * SP;
                     data_t sum = 0;
                     for (int n = N_s; n < N_e; ++n)
-                        PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
+                        PRAGMA_OMP_SIMD(reduction(+ : sum))
                         for (int sp = S_s; sp < S_e; ++sp) {
                             sum += src[off + n * C * SP + sp];
                         }
@@ -149,7 +149,7 @@ void ncsp_batch_normalization_fwd_t::execute_forward() {
                     size_t off = c + C_off;
                     data_t sum = 0.;
                     for (int n = N_s; n < N_e; ++n)
-                        PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : sum))
+                        PRAGMA_OMP_SIMD(reduction(+ : sum))
                         for (int sp = S_s; sp < S_e; ++sp) {
                             data_t m = src[off * SP + n * C * SP + sp]
                                     - mean[off];
@@ -275,7 +275,7 @@ void ncsp_batch_normalization_bwd_t::execute_backward() {
                 data_t diff_gamma = 0.0, diff_beta = 0.0;
                 data_t v_mean = mean[off];
                 for (int n = N_s; n < N_e; ++n)
-                    PRAGMA_OMP_SIMD_CLAUSE(reduction(+ : diff_gamma, diff_beta))
+                    PRAGMA_OMP_SIMD(reduction(+ : diff_gamma, diff_beta))
                     for (int sp = S_s; sp < S_e; ++sp) {
                         const size_t d_off = off * SP + n * C * SP + sp;
                         data_t dd;

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -340,8 +340,7 @@ void nhwc_pooling_bwd_t<data_type>::execute_backward() {
                                                        ow, ws_w_stride);
                 const int index = kd * KH * KW + kh * KW + kw;
 
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int oc = 0; oc < OC; ++oc) {
                     const int index_from_ws =
                                     (MEM_D(ws).data_type() == data_type::u8)
@@ -377,7 +376,7 @@ PRAGMA_OMP_SIMD()
                   ? KW*KH*KD
                   : (ih_end - ih_start)*(iw_end - iw_start)*(id_end - id_start);
 
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int oc = 0; oc < OC; ++oc) {
                     const data_t d = diff_dst[dst_offset_init + oc];
                     // Check if kernel windows are disjoint, in this case

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -20,11 +20,10 @@
 #include "c_types_map.hpp"
 #include "type_helpers.hpp"
 #include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
 #include "nstl.hpp"
 
 #include "nhwc_pooling.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -24,6 +24,8 @@
 
 #include "nhwc_pooling.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -338,7 +340,8 @@ void nhwc_pooling_bwd_t<data_type>::execute_backward() {
                                                        ow, ws_w_stride);
                 const int index = kd * KH * KW + kh * KW + kw;
 
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int oc = 0; oc < OC; ++oc) {
                     const int index_from_ws =
                                     (MEM_D(ws).data_type() == data_type::u8)
@@ -373,7 +376,8 @@ void nhwc_pooling_bwd_t<data_type>::execute_backward() {
                 auto num_summands = (alg == pooling_avg_include_padding)
                   ? KW*KH*KD
                   : (ih_end - ih_start)*(iw_end - iw_start)*(id_end - id_start);
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int oc = 0; oc < OC; ++oc) {
                     const data_t d = diff_dst[dst_offset_init + oc];
                     // Check if kernel windows are disjoint, in this case

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -112,8 +112,7 @@ private:
             unsigned char *ws, const size_t ws_offset, const data_type_t ws_dt,
             const int index) {
         assert(!((use_workspace == false) ^ (!ws))); // ensure ws pointer exists
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int oc = 0; oc < n; ++oc) {
             auto s = src[oc];
             data_t mv = dst[oc];

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -22,10 +22,9 @@
 #include "c_types_map.hpp"
 #include "cpu_engine.hpp"
 #include "cpu_pooling_pd.hpp"
+#include "mkldnn_thread.hpp"
 #include "type_helpers.hpp"
 #include "utils.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/nspc_batch_normalization.cpp
+++ b/src/cpu/nspc_batch_normalization.cpp
@@ -101,7 +101,8 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
             for (int n = N_s; n < N_e; n++)
                 for (int sp = 0; sp < SP; sp++)
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int c = 0; c < C; c++)
                         ws_reduce[C * ithr + c] += src[(size_t)n * SP * C
                             + sp * C + c];
@@ -121,7 +122,8 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
             for (int n = N_s; n < N_e; n++)
                 for (int sp = 0; sp < SP; sp++)
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (int c = 0; c < C; c++) {
                         data_t m = src[(size_t)n * SP * C + sp * C + c]
                             - mean_loc[c];
@@ -144,7 +146,8 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
         for (int n = N_s; n < N_e; n++) {
             for (int sp = 0; sp < SP; sp++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int c = 0; c < C; c++) {
                     data_t sqrt_variance = static_cast<data_t>(
                             1.0f / sqrtf(variance_loc[c] + eps));
@@ -227,7 +230,8 @@ void nspc_batch_normalization_bwd_t::execute_backward() {
 
         for (int n = N_s; n < N_e; n++)
             for (int sp = 0; sp < SP; sp++)
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int c = 0; c < C; c++) {
                     const size_t d_off = (size_t)n * SP * C + sp * C + c;
                     data_t dd;
@@ -259,7 +263,8 @@ void nspc_batch_normalization_bwd_t::execute_backward() {
 
         for (int n = N_s; n < N_e; n++) {
             for (int sp = 0; sp < SP; sp++) {
-#pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int c = 0; c < C; c++) {
                     const size_t d_off = (size_t)n * SP * C + sp * C + c;
                     data_t gamma = use_scaleshift ? scaleshift[c] : 1;

--- a/src/cpu/nspc_batch_normalization.cpp
+++ b/src/cpu/nspc_batch_normalization.cpp
@@ -101,8 +101,7 @@ void nspc_batch_normalization_fwd_t::execute_forward() {
 
             for (int n = N_s; n < N_e; n++)
                 for (int sp = 0; sp < SP; sp++)
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int c = 0; c < C; c++)
                         ws_reduce[C * ithr + c] += src[(size_t)n * SP * C
                             + sp * C + c];
@@ -122,8 +121,7 @@ PRAGMA_OMP_SIMD()
 
             for (int n = N_s; n < N_e; n++)
                 for (int sp = 0; sp < SP; sp++)
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (int c = 0; c < C; c++) {
                         data_t m = src[(size_t)n * SP * C + sp * C + c]
                             - mean_loc[c];
@@ -146,8 +144,7 @@ PRAGMA_OMP_SIMD()
 
         for (int n = N_s; n < N_e; n++) {
             for (int sp = 0; sp < SP; sp++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int c = 0; c < C; c++) {
                     data_t sqrt_variance = static_cast<data_t>(
                             1.0f / sqrtf(variance_loc[c] + eps));
@@ -230,8 +227,7 @@ void nspc_batch_normalization_bwd_t::execute_backward() {
 
         for (int n = N_s; n < N_e; n++)
             for (int sp = 0; sp < SP; sp++)
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int c = 0; c < C; c++) {
                     const size_t d_off = (size_t)n * SP * C + sp * C + c;
                     data_t dd;
@@ -263,8 +259,7 @@ PRAGMA_OMP_SIMD()
 
         for (int n = N_s; n < N_e; n++) {
             for (int sp = 0; sp < SP; sp++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int c = 0; c < C; c++) {
                     const size_t d_off = (size_t)n * SP * C + sp * C + c;
                     data_t gamma = use_scaleshift ? scaleshift[c] : 1;

--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -16,12 +16,11 @@
 
 #include "c_types_map.hpp"
 #include "type_helpers.hpp"
+#include "mkldnn_thread.hpp"
 #include "mkldnn_traits.hpp"
 #include "math_utils.hpp"
 
 #include "ref_convolution.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -21,6 +21,8 @@
 
 #include "ref_convolution.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -16,11 +16,11 @@
 
 #include "c_types_map.hpp"
 #include "type_helpers.hpp"
+#include "mkldnn_thread.hpp"
 #include "mkldnn_traits.hpp"
 #include "math_utils.hpp"
-#include "ref_deconvolution.hpp"
 
-#include "mkldnn_thread.hpp"
+#include "ref_deconvolution.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -75,8 +75,7 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_ncdhw() {
 #   pragma omp parallel for collapse(2) schedule(static)
     for (int mb = 0; mb < MB; ++mb) {
         for (int oc = 0; oc < OC; ++oc) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = ((mb * OC + oc) * SP + sp );
                 dst[offset] += bias[oc];
@@ -102,7 +101,7 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_nCdhwXc() {
                 auto offset = ((mb * OC + oc*blksize)
                     * SP + sp * blksize) ;
 
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int i=0; i<blksize; i++)
                     dst[offset + i] += bias[oc*blksize + i];
             }
@@ -163,8 +162,7 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ncdhw() {
     for (int oc = 0; oc < OC; ++oc) {
         data_t db = 0;
         for (int mb = 0; mb < MB; ++mb) {
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = (mb * OC + oc) * SP + sp;
                 db += diff_dst[offset];
@@ -192,14 +190,13 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc() {
         for (int mb = 0; mb < MB; ++mb) {
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = (mb * OC + oc*blksize) * SP + sp * blksize;
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int i = 0; i<blksize; i++)
                     db[i] += diff_dst[offset+i];
             }
         }
 
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int i = 0; i<blksize; i++)
             diff_bias[oc*blksize+i] = db[i];
     }

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -20,6 +20,8 @@
 #include "math_utils.hpp"
 #include "ref_deconvolution.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -73,7 +75,8 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_ncdhw() {
 #   pragma omp parallel for collapse(2) schedule(static)
     for (int mb = 0; mb < MB; ++mb) {
         for (int oc = 0; oc < OC; ++oc) {
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = ((mb * OC + oc) * SP + sp );
                 dst[offset] += bias[oc];
@@ -98,7 +101,8 @@ void ref_deconvolution_fwd_t::compute_fwd_bias_nCdhwXc() {
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = ((mb * OC + oc*blksize)
                     * SP + sp * blksize) ;
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int i=0; i<blksize; i++)
                     dst[offset + i] += bias[oc*blksize + i];
             }
@@ -159,7 +163,8 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_ncdhw() {
     for (int oc = 0; oc < OC; ++oc) {
         data_t db = 0;
         for (int mb = 0; mb < MB; ++mb) {
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = (mb * OC + oc) * SP + sp;
                 db += diff_dst[offset];
@@ -187,12 +192,14 @@ void ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc() {
         for (int mb = 0; mb < MB; ++mb) {
             for (int sp = 0; sp < SP; ++sp) {
                 auto offset = (mb * OC + oc*blksize) * SP + sp * blksize;
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int i = 0; i<blksize; i++)
                     db[i] += diff_dst[offset+i];
             }
         }
-#       pragma omp simd
+
+PRAGMA_OMP_SIMD()
         for (int i = 0; i<blksize; i++)
             diff_bias[oc*blksize+i] = db[i];
     }

--- a/src/cpu/ref_eltwise.cpp
+++ b/src/cpu/ref_eltwise.cpp
@@ -19,10 +19,9 @@
 #include "c_types_map.hpp"
 #include "type_helpers.hpp"
 #include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
 
 #include "ref_eltwise.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ref_inner_product.cpp
+++ b/src/cpu/ref_inner_product.cpp
@@ -227,13 +227,15 @@ void ref_inner_product_bwd_weights_t<data_type>::execute_backward_weights() {
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (int mb = 1; mb < MB; ++mb) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/ref_inner_product.cpp
+++ b/src/cpu/ref_inner_product.cpp
@@ -227,15 +227,13 @@ void ref_inner_product_bwd_weights_t<data_type>::execute_backward_weights() {
             oc_st = oc_st * blksize;
             oc_e = oc_e * blksize;
 
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int oc = oc_st; oc < oc_e; ++oc) {
                 diff_bias[oc] = diff_dst[oc];
             }
 
             for (int mb = 1; mb < MB; ++mb) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (int oc = oc_st; oc < oc_e; ++oc) {
                     diff_bias[oc] += diff_dst[mb * OC + oc];
                 }

--- a/src/cpu/ref_lrn.cpp
+++ b/src/cpu/ref_lrn.cpp
@@ -22,6 +22,8 @@
 
 #include "ref_lrn.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -116,7 +118,8 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
         {
             const size_t off = (size_t)(mb * CHW + c * H * W + (h * W + w)
                 * blksize);
-            # pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int cc = 0; cc < blksize; ++cc)
                 ker(&dst[off + cc], mb, c + cc, h, w);
         }
@@ -215,7 +218,8 @@ void ref_lrn_bwd_t<data_type>::execute_backward() {
         {
             const size_t off = (size_t)(mb * CHW + c * H * W + (h * W + w)
                 * blksize);
-            # pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (int cc = 0; cc < blksize; ++cc)
                 ker(&diff_src[off + cc], mb, c + cc, h, w);
         }

--- a/src/cpu/ref_lrn.cpp
+++ b/src/cpu/ref_lrn.cpp
@@ -18,11 +18,10 @@
 #include <math.h>
 
 #include "c_types_map.hpp"
+#include "mkldnn_thread.hpp"
 #include "type_helpers.hpp"
 
 #include "ref_lrn.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ref_lrn.cpp
+++ b/src/cpu/ref_lrn.cpp
@@ -118,8 +118,7 @@ void ref_lrn_fwd_t<data_type>::execute_forward() {
         {
             const size_t off = (size_t)(mb * CHW + c * H * W + (h * W + w)
                 * blksize);
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int cc = 0; cc < blksize; ++cc)
                 ker(&dst[off + cc], mb, c + cc, h, w);
         }
@@ -218,8 +217,7 @@ void ref_lrn_bwd_t<data_type>::execute_backward() {
         {
             const size_t off = (size_t)(mb * CHW + c * H * W + (h * W + w)
                 * blksize);
-
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (int cc = 0; cc < blksize; ++cc)
                 ker(&diff_src[off + cc], mb, c + cc, h, w);
         }

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -18,13 +18,12 @@
 #include <math.h>
 
 #include "c_types_map.hpp"
-#include "type_helpers.hpp"
 #include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
 #include "nstl.hpp"
+#include "type_helpers.hpp"
 
 #include "ref_pooling.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -24,6 +24,8 @@
 
 #include "ref_pooling.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/ref_rnn.cpp
+++ b/src/cpu/ref_rnn.cpp
@@ -30,12 +30,11 @@
  */
 #include "c_types_map.hpp"
 #include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
 #include "mkldnn_traits.hpp"
 #include "type_helpers.hpp"
 
 #include "ref_rnn.hpp"
-
-#include "mkldnn_thread.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/ref_rnn.cpp
+++ b/src/cpu/ref_rnn.cpp
@@ -117,8 +117,7 @@ elemwise_sig(_ref_rnn_common_t<prop_kind::forward>::lstm_elemwise) {
 
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < dic; j++) {
             ws_gates(i, 0, j) = logistic_fwd(ws_gates(i, 0, j) + bias(0, j));
             ws_gates(i, 1, j) = logistic_fwd(ws_gates(i, 1, j) + bias(1, j));
@@ -149,8 +148,7 @@ elemwise_sig(_ref_rnn_common_t<prop_kind::backward>::lstm_elemwise) {
 
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < dic; j++) {
             float Ct = states_t_l(1, i, j);
             /// @todo save it in the workspace in fwd pass or recompute it to
@@ -281,8 +279,7 @@ cell_execution_sig(_ref_rnn_common_t<prop_kind::forward>::cell_execution_gru) {
     // 3. activation zt and rt + elemwise multiplication rt,ht-1
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < dic; j++) {
             ws_gates(i, 0, j) = logistic_fwd(ws_gates(i, 0, j) + bias(0, j));
             ws_gates(i, 1, j) = logistic_fwd(ws_gates(i, 1, j) + bias(1, j));
@@ -298,8 +295,7 @@ PRAGMA_OMP_SIMD()
     // 5. activation h~t + calculate ht
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < dic; j++) {
             ws_gates(i, 2, j) = tanh_fwd(ws_gates(i, 2, j) + bias(2, j));
             states_t_l(i, j) = states_tm1_l(i, j) * ws_gates(i, 0, j) +
@@ -330,8 +326,7 @@ cell_execution_sig(_ref_rnn_common_t<prop_kind::backward>::cell_execution_gru) {
     // dht-1 (part) = dh * G0
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < dic; j++) {
             float h = states_tm1_l(i, j);
             float dHt = diff_states_tp1_l(0, i, j)
@@ -359,8 +354,7 @@ PRAGMA_OMP_SIMD()
     //h * G1 (required for dWh)
 #pragma omp parallel for
     for (int i = 0; i < batch; i++) {
-
-PRAGMA_OMP_SIMD()
+        PRAGMA_OMP_SIMD()
         for (int j = 0; j < dic; j++) {
             float h = states_tm1_l(i, j);
             float G1 =  ws_gates(i, 1, j);

--- a/src/cpu/simple_concat.cpp
+++ b/src/cpu/simple_concat.cpp
@@ -51,8 +51,8 @@ void simple_concat_t<data_type>::execute() {
     for (int i = 0; i < perm[concat_dim]; i++)
         os[i] = o_d.blocking_desc().strides[0][iperm[i]];
     dims_t phys_dims;
-    for (ptrdiff_t i = 0; i < sizeof(phys_dims) / sizeof(phys_dims[0]); i++)
-        phys_dims[i] = (i < perm[concat_dim]) ?
+    for (size_t i = 0; i < sizeof(phys_dims)/sizeof(phys_dims[0]); i++)
+        phys_dims[i] = (i < (size_t)perm[concat_dim]) ?
                 o_d.dims()[iperm[i]] / blk.block_dims[iperm[i]] :
                 1;
 
@@ -62,7 +62,7 @@ void simple_concat_t<data_type>::execute() {
             const data_t *i = &input_ptrs[a][0];
             data_t *o = &output_ptrs[a][0];
 #           pragma omp parallel for
-            for (ptrdiff_t e = 0; e < static_cast<ptrdiff_t>(nelems_to_copy[a]); ++e)
+            for (ptrdiff_t e = 0; e < (ptrdiff_t)nelems_to_copy[a]; ++e)
                 o[e] = i[e];
         }
         break;

--- a/src/cpu/simple_concat.cpp
+++ b/src/cpu/simple_concat.cpp
@@ -83,7 +83,7 @@ void simple_concat_t<data_type>::execute() {
                                 const data_t *i = &input_ptrs[a][in_off];
                                 data_t *o = &output_ptrs[a][out_off];
 
-PRAGMA_OMP_SIMD()
+                                PRAGMA_OMP_SIMD()
                                 for (size_t e = 0; e < nelems_to_copy[a]; ++e)
                                     o[e] = i[e];
                             }

--- a/src/cpu/simple_concat.cpp
+++ b/src/cpu/simple_concat.cpp
@@ -14,9 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "simple_concat.hpp"
-
 #include "mkldnn_thread.hpp"
+
+#include "simple_concat.hpp"
 
 namespace mkldnn {
 namespace impl {

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -30,8 +30,6 @@
 
 #include "simple_q10n.hpp"
 
-#include "mkldnn_thread.hpp"
-
 namespace mkldnn {
 namespace impl {
 namespace cpu {

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -249,8 +249,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c], rmode);
@@ -259,8 +258,7 @@ PRAGMA_OMP_SIMD()
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c],
@@ -270,8 +268,7 @@ PRAGMA_OMP_SIMD()
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c], alpha, rmode);
@@ -280,8 +277,7 @@ PRAGMA_OMP_SIMD()
                 } else {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c],
@@ -293,8 +289,7 @@ PRAGMA_OMP_SIMD()
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c], rmode);
@@ -303,8 +298,7 @@ PRAGMA_OMP_SIMD()
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c],
@@ -314,8 +308,7 @@ PRAGMA_OMP_SIMD()
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c], alpha, rmode);
@@ -324,8 +317,7 @@ PRAGMA_OMP_SIMD()
                 } else {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c],
@@ -378,9 +370,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nsize) {
             if (alpha == 1.0 && beta == 0) {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
-                
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] =
@@ -388,8 +378,7 @@ PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                     }
                 }
             } else {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] = data_t<type_o>(
@@ -505,9 +494,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w], rmode);
@@ -516,8 +503,7 @@ PRAGMA_OMP_SIMD()
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w],
@@ -527,8 +513,7 @@ PRAGMA_OMP_SIMD()
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w], alpha, rmode);
@@ -537,8 +522,7 @@ PRAGMA_OMP_SIMD()
                 } else {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w],
@@ -550,8 +534,7 @@ PRAGMA_OMP_SIMD()
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c], rmode);
@@ -560,8 +543,7 @@ PRAGMA_OMP_SIMD()
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c],
@@ -571,8 +553,7 @@ PRAGMA_OMP_SIMD()
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c], alpha, rmode);
@@ -581,8 +562,7 @@ PRAGMA_OMP_SIMD()
                 } else {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-
-PRAGMA_OMP_SIMD()
+                        PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c],
@@ -679,8 +659,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nrows, const int ncols) {
             if (alpha == 1.0 && beta == 0) {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -691,8 +670,7 @@ PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                     }
                 }
             } else {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -741,8 +719,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0) {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -755,8 +732,7 @@ PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                     }
                 }
             } else {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? O * os[0] + oc :
@@ -1331,8 +1307,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0.0) {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -1345,8 +1320,7 @@ PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                     }
                 }
             } else {
-
-PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? ic * blksize + oc :
@@ -1779,29 +1753,25 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
             round_mode_t rmode = pd->attr()->round_mode_;
 
             if (alpha == 1.0 && beta == 0.0) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_a1b0<data_t<type_i>, data_t<type_o>>()
                                 (input[e], rmode);
                 }
             } else if (alpha == 1.0) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_a1<data_t<type_i>, data_t<type_o>>()
                                 (input[e], output[e], beta, rmode);
                 }
             } else if (beta == 0.0) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_b0<data_t<type_i>, data_t<type_o>>()
                                 (input[e], alpha, rmode);
                 }
             } else {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz<data_t<type_i>, data_t<type_o>>()
                                 (input[e], output[e], alpha, beta, rmode);
@@ -1810,29 +1780,25 @@ PRAGMA_OMP_SIMD()
 
             if (rem_elems != 0 && ithr == nthr - 1){
                 if (alpha == 1.0 && beta == 0.0) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_a1b0<data_t<type_i>,
                             data_t<type_o>>()(input[e], rmode);
                     }
                 } else if (alpha == 1.0) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_a1<data_t<type_i>,
                             data_t<type_o>>()(input[e], output[e], beta, rmode);
                     }
                 } else if (beta == 0.0) {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_b0<data_t<type_i>,
                             data_t<type_o>>()(input[e], alpha, rmode);
                     }
                 } else {
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz<data_t<type_i>, data_t<type_o>>()
                                     (input[e], output[e], alpha, beta, rmode);
@@ -1888,8 +1854,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     size_t dim1_e =
                         dim1_s + work_rem > nelems_no_d0 ? nelems_no_d0
                         : dim1_s + work_rem;
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (size_t e = dim1_s; e < dim1_e; ++e){
                         output[os * n + e] = data_t<type_o>(input[is * n + e]);
                     }
@@ -1910,8 +1875,7 @@ PRAGMA_OMP_SIMD()
                     size_t dim1_e =
                         dim1_s + work_rem > nelems_no_d0 ? nelems_no_d0
                         : dim1_s + work_rem;
-
-PRAGMA_OMP_SIMD()
+                    PRAGMA_OMP_SIMD()
                     for (size_t e = dim1_s; e < dim1_e; ++e){
                         output[os * n + e] = data_t<type_o>(
                                 alpha * input[is * n + e]

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -30,6 +30,8 @@
 
 #include "simple_q10n.hpp"
 
+#include "mkldnn_thread.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -247,7 +249,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c], rmode);
@@ -256,7 +259,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c],
@@ -266,7 +270,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c], alpha, rmode);
@@ -275,7 +280,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * os[1] + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[C * blksize + c],
@@ -287,7 +293,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c], rmode);
@@ -296,7 +303,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c],
@@ -306,7 +314,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c], alpha, rmode);
@@ -315,7 +324,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int C = 0; C < dims[1] / blksize; ++C) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < blksize; ++c) {
                             o[C * blksize + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[C * is[1] + c],
@@ -368,7 +378,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nsize) {
             if (alpha == 1.0 && beta == 0) {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] =
@@ -376,7 +388,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] = data_t<type_o>(
@@ -492,7 +505,9 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w], rmode);
@@ -501,7 +516,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w],
@@ -511,7 +527,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w], alpha, rmode);
@@ -520,7 +537,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[w * os[3] + c] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[c * is[1] + w],
@@ -532,7 +550,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 if (alpha == 1.0 && beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_a1b0<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c], rmode);
@@ -541,7 +560,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (alpha == 1.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_a1<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c],
@@ -551,7 +571,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else if (beta == 0.0) {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz_b0<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c], alpha, rmode);
@@ -560,7 +581,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                 } else {
 #                   pragma unroll
                     for (int w = 0; w < dims[3]; ++w) {
-#                       pragma omp simd
+
+PRAGMA_OMP_SIMD()
                         for (int c = 0; c < dims[1]; ++c) {
                             o[c * os[1] + w] = qz<data_t<type_i>,
                                 data_t<type_o>>()(i[w * is[3] + c],
@@ -657,7 +679,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nrows, const int ncols) {
             if (alpha == 1.0 && beta == 0) {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -668,7 +691,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -717,7 +741,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0) {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -730,7 +755,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? O * os[0] + oc :
@@ -1305,7 +1331,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0.0) {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -1318,7 +1345,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-#               pragma omp simd collapse(2)
+
+PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? ic * blksize + oc :
@@ -1751,25 +1779,29 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
             round_mode_t rmode = pd->attr()->round_mode_;
 
             if (alpha == 1.0 && beta == 0.0) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_a1b0<data_t<type_i>, data_t<type_o>>()
                                 (input[e], rmode);
                 }
             } else if (alpha == 1.0) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_a1<data_t<type_i>, data_t<type_o>>()
                                 (input[e], output[e], beta, rmode);
                 }
             } else if (beta == 0.0) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz_b0<data_t<type_i>, data_t<type_o>>()
                                 (input[e], alpha, rmode);
                 }
             } else {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start; e < end; ++e) {
                     output[e] = qz<data_t<type_i>, data_t<type_o>>()
                                 (input[e], output[e], alpha, beta, rmode);
@@ -1778,25 +1810,29 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
             if (rem_elems != 0 && ithr == nthr - 1){
                 if (alpha == 1.0 && beta == 0.0) {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_a1b0<data_t<type_i>,
                             data_t<type_o>>()(input[e], rmode);
                     }
                 } else if (alpha == 1.0) {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_a1<data_t<type_i>,
                             data_t<type_o>>()(input[e], output[e], beta, rmode);
                     }
                 } else if (beta == 0.0) {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz_b0<data_t<type_i>,
                             data_t<type_o>>()(input[e], alpha, rmode);
                     }
                 } else {
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (size_t e = nelems - rem_elems; e < nelems; ++e) {
                         output[e] = qz<data_t<type_i>, data_t<type_o>>()
                                     (input[e], output[e], alpha, beta, rmode);
@@ -1852,7 +1888,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     size_t dim1_e =
                         dim1_s + work_rem > nelems_no_d0 ? nelems_no_d0
                         : dim1_s + work_rem;
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (size_t e = dim1_s; e < dim1_e; ++e){
                         output[os * n + e] = data_t<type_o>(input[is * n + e]);
                     }
@@ -1873,7 +1910,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     size_t dim1_e =
                         dim1_s + work_rem > nelems_no_d0 ? nelems_no_d0
                         : dim1_s + work_rem;
-#                   pragma omp simd
+
+PRAGMA_OMP_SIMD()
                     for (size_t e = dim1_s; e < dim1_e; ++e){
                         output[os * n + e] = data_t<type_o>(
                                 alpha * input[is * n + e]
@@ -1930,14 +1968,14 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         const size_t nelems = input_d.nelems();
         const int smask = pd->attr()->output_scales_.mask_;
         const int ndims_mask = math::ilog2q(smask + 1);
-        const size_t D_mask = utils::array_product(input_d.dims(), ndims_mask);
-        const size_t D_rest = nelems / D_mask;
+        const ptrdiff_t D_mask = utils::array_product(input_d.dims(), ndims_mask);
+        const ptrdiff_t D_rest = nelems / D_mask;
 
         const float *scales = pd->attr()->output_scales_.scales_;
 
 #       pragma omp parallel for collapse(2)
-        for (size_t dm = 0; dm < D_mask; ++dm)
-        for (size_t dr = 0; dr < D_rest; ++dr) {
+        for (ptrdiff_t dm = 0; dm < D_mask; ++dm)
+        for (ptrdiff_t dr = 0; dr < D_rest; ++dr) {
             const float scale = scales[dm];
 
             const size_t e = dm * D_rest + dr;

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -368,7 +368,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nsize) {
             if (alpha == 1.0 && beta == 0) {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] =
@@ -376,7 +376,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int n = 0; n < nsize; n++) {
                     for (int c = 0; c < blksize; ++c) {
                         o[n * o_st[0] + c * co_mult] = data_t<type_o>(
@@ -657,7 +657,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o,
                 const int nrows, const int ncols) {
             if (alpha == 1.0 && beta == 0) {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -668,7 +668,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int row = 0; row < nrows; ++row) {
                     for (int col = 0; col < ncols; ++col) {
                         const auto o_idx = row * ostrides[0]
@@ -717,7 +717,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0) {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -730,7 +730,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int O = 0; O < dims[0] / blksize; ++O) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? O * os[0] + oc :
@@ -1305,7 +1305,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         auto ker = [&](const data_t<type_i> *i, data_t<type_o> *o) {
             if (alpha == 1.0 && beta == 0.0) {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         if (order_keep) {
@@ -1318,7 +1318,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
                     }
                 }
             } else {
-                PRAGMA_OMP_SIMD_CLAUSE(collapse(2))
+                PRAGMA_OMP_SIMD(collapse(2))
                 for (int ic = 0; ic < blksize; ++ic) {
                     for (int oc = 0; oc < blksize; ++oc) {
                         const auto dst_off = order_keep ? ic * blksize + oc :

--- a/src/cpu/simple_sum.cpp
+++ b/src/cpu/simple_sum.cpp
@@ -52,12 +52,14 @@ void simple_sum_t<data_type>::execute() {
         for (size_t nb = start; nb < end; ++nb) {
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < end_e; e++) {
                 output[e] = data_t(scales[0] * input_ptrs[0][e]);
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += data_t(scales[a] * input_ptrs[a][e]);
                 }
@@ -67,12 +69,14 @@ void simple_sum_t<data_type>::execute() {
         if (tail != 0 && ithr == nthr - 1) {
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
-#           pragma omp simd
+
+PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < end_e; e++) {
                 output[e] = data_t(scales[0] * input_ptrs[0][e]);
             }
             for (int a = 1; a < num_arrs; a++) {
-#               pragma omp simd
+
+PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += data_t(scales[a] * input_ptrs[a][e]);
                 }

--- a/src/cpu/simple_sum.cpp
+++ b/src/cpu/simple_sum.cpp
@@ -53,13 +53,12 @@ void simple_sum_t<data_type>::execute() {
             size_t start_e = nb * block_size;
             size_t end_e = start_e + block_size;
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < end_e; e++) {
                 output[e] = data_t(scales[0] * input_ptrs[0][e]);
             }
             for (int a = 1; a < num_arrs; a++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += data_t(scales[a] * input_ptrs[a][e]);
                 }
@@ -70,13 +69,12 @@ PRAGMA_OMP_SIMD()
             size_t start_e = nelems - tail;
             size_t end_e = nelems;
 
-PRAGMA_OMP_SIMD()
+            PRAGMA_OMP_SIMD()
             for (size_t e = start_e; e < end_e; e++) {
                 output[e] = data_t(scales[0] * input_ptrs[0][e]);
             }
             for (int a = 1; a < num_arrs; a++) {
-
-PRAGMA_OMP_SIMD()
+                PRAGMA_OMP_SIMD()
                 for (size_t e = start_e; e < end_e; e++) {
                     output[e] += data_t(scales[a] * input_ptrs[a][e]);
                 }

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -45,6 +45,10 @@
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define collapse(x)
+#endif
+
 #define OK 0
 #define FAIL 1
 

--- a/tests/benchdnn/conv/ref_wino.cpp
+++ b/tests/benchdnn/conv/ref_wino.cpp
@@ -346,14 +346,6 @@ void compute_wino_ref_fwd(const prb_t *p, dnn_mem_t &src_m, dnn_mem_t &wei_m,
     array_offset_calculator<float, 6> M(sp._m_ptr, sp.alpha, sp.alpha, p->oc,
             p->mb, sp.h_tiles, sp.w_tiles);
 
-    float I[6][6];
-    float F[3][3];
-    float O[4][4];
-
-    float _v[6][6];
-    float _u[6][6];
-    float _m[6][6];
-
     SAFE_V(p->kh == 3 ? OK : FAIL);
     SAFE_V(p->kw == 3 ? OK : FAIL);
 
@@ -366,7 +358,15 @@ void compute_wino_ref_fwd(const prb_t *p, dnn_mem_t &src_m, dnn_mem_t &wei_m,
 
 #pragma omp parallel
     {
-#pragma omp for collapse(4) private(I, _v)
+    float I[6][6];
+    float F[3][3];
+    float O[4][4];
+
+    float _v[6][6];
+    float _u[6][6];
+    float _m[6][6];
+
+#pragma omp for collapse(4)
     /* src_transform v <- B_t * d * B */
     for (int img = 0; img < p->mb; img++) {
         for (int c = 0; c < p->ic; c++) {
@@ -405,7 +405,7 @@ void compute_wino_ref_fwd(const prb_t *p, dnn_mem_t &src_m, dnn_mem_t &wei_m,
         }
     }
 
-#pragma omp for collapse(2) private(F, _u)
+#pragma omp for collapse(2)
     /* wei_transform u <- G * g * G_t */
     for (int oc = 0; oc < p->oc; ++oc) {
         for (int ic = 0; ic < p->ic; ++ic) {
@@ -437,7 +437,7 @@ void compute_wino_ref_fwd(const prb_t *p, dnn_mem_t &src_m, dnn_mem_t &wei_m,
         }
     }
 
-#pragma omp for collapse(4) private(O, _m)
+#pragma omp for collapse(4)
     /* Y = A_t *m * A */
     for (int oc = 0; oc < p->oc; ++oc) {
         for (int img = 0; img < p->mb; ++img) {
@@ -517,14 +517,6 @@ void compute_wino_ref_bwd_d(const prb_t *p, dnn_mem_t &diff_src_m,
     array_offset_calculator<float, 6> M(sp._v_ptr, sp.alpha, sp.alpha, p->ic,
             p->mb, sp.h_tiles, sp.w_tiles);
 
-    float I[6][6];
-    float F[3][3];
-    float O[4][4];
-
-    float _v[6][6];
-    float _u[6][6];
-    float _m[6][6];
-
     SAFE_V(p->kh == 3 ? OK : FAIL);
     SAFE_V(p->kw == 3 ? OK : FAIL);
 
@@ -537,7 +529,15 @@ void compute_wino_ref_bwd_d(const prb_t *p, dnn_mem_t &diff_src_m,
 
 #pragma omp parallel
     {
-#pragma omp for collapse(4) private(I, _v)
+    float I[6][6];
+    float F[3][3];
+    float O[4][4];
+
+    float _v[6][6];
+    float _u[6][6];
+    float _m[6][6];
+
+#pragma omp for collapse(4)
     /* diff_src transform v <- B_t * d * B */
     for (int img = 0; img < p->mb; img++) {
         for (int c = 0; c < p->oc; c++) {
@@ -577,7 +577,7 @@ void compute_wino_ref_bwd_d(const prb_t *p, dnn_mem_t &diff_src_m,
         }
     }
 
-#pragma omp for collapse(2) private(F, _u)
+#pragma omp for collapse(2)
     /* wei_transform u <- G * g * G_t */
     for (int ic = 0; ic < p->ic; ++ic) {
         for (int oc = 0; oc < p->oc; ++oc) {
@@ -609,7 +609,7 @@ void compute_wino_ref_bwd_d(const prb_t *p, dnn_mem_t &diff_src_m,
         }
     }
 
-#pragma omp for collapse(4) private(O, _m)
+#pragma omp for collapse(4)
     /* diff_dst: Y = A_t *m * A */
     for (int c = 0; c < p->ic; ++c) {
         for (int img = 0; img < p->mb; ++img) {
@@ -656,14 +656,6 @@ void compute_wino_ref_bwd_w(const prb_t *p, dnn_mem_t &src_m,
     array_offset_calculator<float, 6> M(sp._m_ptr, sp.alpha, sp.alpha, p->oc,
             p->mb, sp.h_tiles, sp.w_tiles);
 
-    float I[6][6];
-    float F[6][6];
-    float O[6][6];
-
-    float _v[6][6];
-    float _u[3][3];
-    float _m[6][6];
-
     SAFE_V(p->kh == 3 ? OK : FAIL);
     SAFE_V(p->kw == 3 ? OK : FAIL);
 
@@ -675,7 +667,15 @@ void compute_wino_ref_bwd_w(const prb_t *p, dnn_mem_t &src_m,
 
 #pragma omp parallel
     {
-#pragma omp for collapse(4) private(I, _v)
+    float I[6][6];
+    float F[6][6];
+    float O[6][6];
+
+    float _v[6][6];
+    float _u[3][3];
+    float _m[6][6];
+
+#pragma omp for collapse(4)
     /* src transform v <- B_t * d * B */
     for (int img = 0; img < p->mb; img++) {
         for (int hfm = 0; hfm < sp.h_tiles; hfm++) {
@@ -714,7 +714,7 @@ void compute_wino_ref_bwd_w(const prb_t *p, dnn_mem_t &src_m,
         }
     }
 
-#pragma omp for collapse(4) private(O, _m)
+#pragma omp for collapse(4)
     /* diff_dst transform */
     for (int oc = 0; oc < p->oc; oc++) {
         for (int img = 0; img < p->mb; img++) {
@@ -762,7 +762,7 @@ void compute_wino_ref_bwd_w(const prb_t *p, dnn_mem_t &src_m,
         }
     }
 
-#pragma omp for collapse(2) private(F, _u)
+#pragma omp for collapse(2)
     for (int oc = 0; oc < p->oc; ++oc) {
         for (int ic = 0; ic < p->ic; ++ic) {
             for (int j = 0; j < sp.alpha; j++) {

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -121,9 +121,9 @@ inline int compare_dat(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *r) {
 
 inline void fill_src(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *r) {
     dnn_mem_t mem_00(mem_dt.md_, mkldnn_f32, mkldnn_nchw);
-    const size_t sz = mem_00.nelems();
+    const ptrdiff_t sz = (ptrdiff_t)mem_00.nelems();
 #   pragma omp parallel for
-    for (size_t i = 0; i < sz; ++i)
+    for (ptrdiff_t i = 0; i < sz; ++i)
         ((float*)mem_00)[i] = 1 + (i % 3); // 1 + sin(0.2* (i % 17));
 
     mem_dt.reorder(mem_00);
@@ -137,9 +137,9 @@ inline void fill_src(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *r) {
 
 inline void fill_wei(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *r) {
     dnn_mem_t mem_00(mem_dt.md_, mkldnn_f32, mkldnn_oihw);
-    const size_t sz = mem_00.nelems();
+    const ptrdiff_t sz = (ptrdiff_t)mem_00.nelems();
 #   pragma omp parallel for
-    for (size_t i = 0; i < sz; ++i)
+    for (ptrdiff_t i = 0; i < sz; ++i)
         ((float*)mem_00)[i] = (i % 4) - 1 ; // 1 + sin(0.2* (i % 17));
 
     mem_dt.reorder(mem_00);
@@ -168,9 +168,9 @@ inline void fill_bia(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *r) {
 
 inline void fill_dst(dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *r) {
     dnn_mem_t mem_00(mem_dt.md_, mkldnn_f32, mkldnn_nc);
-    const size_t sz = mem_00.nelems();
+    const ptrdiff_t sz = (ptrdiff_t)mem_00.nelems();
 #   pragma omp parallel for
-    for (size_t i = 0; i < sz; ++i)
+    for (ptrdiff_t i = 0; i < sz; ++i)
         ((float*)mem_00)[i] = 1 + (i % 3); // 1 + sin(0.2* (i % 17));
 
     mem_dt.reorder(mem_00);

--- a/tests/gtests/mkldnn_test_common.hpp
+++ b/tests/gtests/mkldnn_test_common.hpp
@@ -24,6 +24,10 @@
 
 #include "gtest/gtest.h"
 
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define collapse(x)
+#endif
+
 #include "mkldnn.hpp"
 
 template <typename data_t> struct data_traits { };
@@ -237,7 +241,7 @@ static void fill_data(const size_t size, data_t *data, data_t mean,
         data_t deviation, double sparsity = 1.)
 {
 #   pragma omp parallel for schedule(static)
-    for (size_t n = 0; n < size; n++) {
+    for (ptrdiff_t n = 0; n < (ptrdiff_t)size; n++) {
         data[n] = set_value<data_t>(n, mean, deviation, sparsity);
     }
 }
@@ -247,7 +251,7 @@ static void fill_data(const size_t size, data_t *data, double sparsity = 1.,
         bool init_negs = false)
 {
 #   pragma omp parallel for schedule(static)
-    for (size_t n = 0; n < size; n++) {
+    for (ptrdiff_t n = 0; n < (ptrdiff_t)size; n++) {
         data[n] = set_value<data_t>(n, data_t(1), data_t(2e-1), sparsity);
 
         if (init_negs && n%4 == 0U)

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -129,7 +129,7 @@ protected:
         const size_t sz =
             dst->get_primitive_desc().get_size() / sizeof(data_t);
         // overwriting dst to prevent false positives for test cases.
-#	pragma omp parallel for
+#       pragma omp parallel for
         for (ptrdiff_t i = 0; i < (ptrdiff_t)sz; i++) {
             dst_data[i] = -32;
         }

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -129,8 +129,8 @@ protected:
         const size_t sz =
             dst->get_primitive_desc().get_size() / sizeof(data_t);
         // overwriting dst to prevent false positives for test cases.
-# pragma omp parallel for
-        for (size_t i = 0; i < sz; i++) {
+#	pragma omp parallel for
+        for (ptrdiff_t i = 0; i < (ptrdiff_t)sz; i++) {
             dst_data[i] = -32;
         }
 


### PR DESCRIPTION
Added two new macros to handle pragma omp simd. One that doesn't take any clauses/args, and one that does. On pure msvc, these will define a nop that will not warn or error. On all other compilers, they will expand properly.

The global scratch pad struct had omp threadprivate declared on static members. This is supported only in OpenMP >= 3.0. As such, using a guard between msvc and everything else, made a second msvc-specific implementation with an internal thread-local storage system as a work around.

Replaced index variable types where necessary on loops decorated with omp parallel in order to avoid a compiler error from msvc that complains about violating OpenMP standards of requiring such indices to be signed types.