### PR TITLE
Avoid downloading `mklml` twice

### DIFF
--- a/scripts/prepare_mkl.bat
+++ b/scripts/prepare_mkl.bat
@@ -21,9 +21,9 @@ powershell.exe -command "if ($PSVersionTable.PSVersion.Major -ge 3) {exit 1} els
 set MKLURLROOT=https://github.com/intel/mkl-dnn/releases/download/v0.16/
 set MKLVERSION=2019.0.20180710
 
-set MKLPACKAGE=mklml_win_%MKLVERSION%.zip
+set MKLPACKAGE=mklml_win_%MKLVERSION%
 
-set MKLURL=%MKLURLROOT%%MKLPACKAGE%
+set MKLURL=%MKLURLROOT%%MKLPACKAGE%.zip
 if /i "%1"=="" (
 	set DST=%~dp0..\external
 ) else (
@@ -32,19 +32,24 @@ if /i "%1"=="" (
 
 if not exist %DST% mkdir %DST%
 
-powershell.exe -command "if (Get-Command Invoke-WebRequest -errorAction SilentlyContinue){[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest %MKLURL% -OutFile %DST%\%MKLPACKAGE%} else {exit 1}" && goto Unpack || goto Error_load
+if not exist "%DST%\%MKLPACKAGE%\license.txt" (
+	powershell.exe -command "if (Get-Command Invoke-WebRequest -errorAction SilentlyContinue){[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest %MKLURL% -OutFile %DST%\%MKLPACKAGE%.zip} else {exit 1}" && goto Unpack || goto Error_load
 
 :Unpack
-powershell.exe -command "if (Get-Command Add-Type -errorAction SilentlyContinue) {Add-Type -Assembly \"System.IO.Compression.FileSystem\"; try { [IO.Compression.zipfile]::ExtractToDirectory(\"%DST%\%MKLPACKAGE%\", \"%DST%\")}catch{$_.exception ; exit 1}} else {exit 1}" && goto Exit || goto Error_unpack
+	powershell.exe -command "if (Get-Command Add-Type -errorAction SilentlyContinue) {Add-Type -Assembly \"System.IO.Compression.FileSystem\"; try { [IO.Compression.zipfile]::ExtractToDirectory(\"%DST%\%MKLPACKAGE%.zip\", \"%DST%\")}catch{$_.exception ; exit 1}} else {exit 1}" && goto Exit || goto Error_unpack
 
 :Error_load
-echo prepare_mkl.bat : Error: Failed to load %MKLURL% to %DST%, try to load it manually
-exit /B 1
+	echo prepare_mkl.bat : Error: Failed to load %MKLURL% to %DST%, try to load it manually
+	exit /B 1
 
 :Error_unpack
-echo prepare_mkl.bat : Error: Failed to unpack %DST%\%MKLPACKAGE% to %DST%, try unpack the archive manually
-exit /B 1
+	echo prepare_mkl.bat : Error: Failed to unpack %DST%\%MKLPACKAGE%.zip to %DST%, try unpack the archive manually
+	exit /B 1
 
 :Exit
-echo Downloaded and unpacked Intel(R) MKL small libraries to %DST%
-exit /B 0
+	echo Downloaded and unpacked Intel^(R^) MKL small libraries to %DST%
+	exit /B 0
+) else (
+	echo Intel^(R^) MKL small libraries are already installed in %DST%
+	exit /B 0
+)

--- a/scripts/prepare_mkl.sh
+++ b/scripts/prepare_mkl.sh
@@ -20,32 +20,36 @@ MKLVERSION="2019.0.20180710"
 
 os=`uname`
 if [ "$os" = "Linux" ]; then
-  MKLPACKAGE="mklml_lnx_${MKLVERSION}.tgz"
+  MKLPACKAGE="mklml_lnx_${MKLVERSION}"
 elif [ "$os" = "Darwin" ]; then
-  MKLPACKAGE="mklml_mac_${MKLVERSION}.tgz"
+  MKLPACKAGE="mklml_mac_${MKLVERSION}"
 else
   echo "Cannot identify operating system. Try downloading package manually."
   exit 1
 fi
 
-MKLURL=${MKLURLROOT}${MKLPACKAGE}
+MKLURL=${MKLURLROOT}${MKLPACKAGE}.tgz
 DST=`dirname $0`/../external
 mkdir -p $DST
 DST=`cd $DST;pwd`
 
-if [ -x "$(command -v curl)" ]; then
-  curl -L -o "${DST}/${MKLPACKAGE}" "$MKLURL"
-elif [ -x "$(command -v wget)" ]; then
-  wget -O "${DST}/${MKLPACKAGE}" "$MKLURL"
+if [ ! -e "${DST}/${MKLPACKAGE}/license.txt" ]; then
+  if [ -x "$(command -v curl)" ]; then
+    curl -L -o "${DST}/${MKLPACKAGE}.tgz" "$MKLURL"
+  elif [ -x "$(command -v wget)" ]; then
+    wget -O "${DST}/${MKLPACKAGE}.tgz" "$MKLURL"
+  else
+    echo "curl or wget not available"
+    exit 1
+  fi
+
+  if [ \! $? ]; then
+    echo "Download from $MKLURL to $DST failed"
+    exit 1
+  fi
+
+  tar -xzf "$DST/${MKLPACKAGE}.tgz" -C $DST
+  echo "Downloaded and unpacked Intel(R) MKL small libraries to $DST"
 else
-  echo "curl or wget not available"
-  exit 1
+  echo "Intel(R) MKL small libraries are already installed in $DST"
 fi
-
-if [ \! $? ]; then
-  echo "Download from $MKLURL to $DST failed"
-  exit 1
-fi
-
-tar -xzf "$DST/${MKLPACKAGE}" -C $DST
-echo "Downloaded and unpacked Intel(R) MKL small libraries to $DST"


### PR DESCRIPTION
Fix ` scripts/prepare_mkl.sh` and `.bat` to avoid downloading `mklml` twice when executing it again.