### PR TITLE
Add DL4J to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Intel MKL-DNN is used in the following software products:
 * [OpenVINO(TM) toolkit](https://software.intel.com/en-us/openvino-toolkit)
 * [Intel(R) Nervana(TM) Graph](https://github.com/NervanaSystems/ngraph)
 * [Menoh\*](https://github.com/pfnet-research/menoh)
+* [DeepLearning4J\*](https://deeplearning4j.org)
 
 ## License
 Intel MKL-DNN is licensed under


### PR DESCRIPTION
The DeepLearning4J framework also uses MKL-DNN by default now if you use the nd4j-native-platform as the backend dependency. 

See https://github.com/deeplearning4j/deeplearning4j/pull/5622 for the commit.