### PR TITLE
Fix data race in gemm.cpp

### DIFF
--- a/src/cpu/gemm/gemm.cpp
+++ b/src/cpu/gemm/gemm.cpp
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include <atomic>
 #include <mutex>
 
 #include "mkldnn.h"

--- a/src/cpu/gemm/gemm.cpp
+++ b/src/cpu/gemm/gemm.cpp
@@ -177,15 +177,9 @@ mkldnn_status_t extended_sgemm(const char *transa, const char *transb,
     }
 #endif
     //Generate jit kernel and call sgemm with bias
-    static std::atomic<bool> initialized(false);
-    if (!initialized) {
-        static std::mutex mtx;
-        std::lock_guard<std::mutex> lock(mtx);
-        if (!initialized) {
-            mkldnn::impl::cpu::initialize();
-            initialized = true;
-        }
-    }
+    static std::once_flag initialized;
+    std::call_once(initialized, [] { mkldnn::impl::cpu::initialize(); });
+
     if (bias)
         gemm_bias_impl[trA][trB]->call(
                 transa, transb, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc,

--- a/src/cpu/gemm/gemm.cpp
+++ b/src/cpu/gemm/gemm.cpp
@@ -13,6 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+#include <atomic>
 #include <mutex>
 
 #include "mkldnn.h"
@@ -176,13 +177,13 @@ mkldnn_status_t extended_sgemm(const char *transa, const char *transb,
     }
 #endif
     //Generate jit kernel and call sgemm with bias
-    volatile static int initialized = 0;
+    static std::atomic<bool> initialized(false);
     if (!initialized) {
         static std::mutex mtx;
         std::lock_guard<std::mutex> lock(mtx);
         if (!initialized) {
             mkldnn::impl::cpu::initialize();
-            initialized = 1;
+            initialized = true;
         }
     }
     if (bias)


### PR DESCRIPTION
Using volatile for synchronization is unsafe: https://github.com/google/sanitizers/wiki/ThreadSanitizerAboutRaces#volatile

This popped up in one of our test under thread sanitizer.