### PR TITLE
RFC: API changes for the upcoming v1.0

### DIFF
--- a/doc/rfc/api-v1.0/README.md
+++ b/doc/rfc/api-v1.0/README.md
@@ -9,6 +9,9 @@
              Implicit and explicit scratchpad modes;
              Dropping memory primitive descriptor;
              Minor clean ups;
+- 2019-04-20 [v1.0 Preview Candidate 2](https://github.com/intel/mkl-dnn/releases/tag/v1.0-pc2) is published;
+             Introduced support for Intel(R) Processor Graphics;
+             
 
 
 ## Introduction

--- a/doc/rfc/api-v1.0/README.md
+++ b/doc/rfc/api-v1.0/README.md
@@ -1,0 +1,491 @@
+# [RFC] Intel(R) MKL-DNN API 1.0
+
+
+## CHANGES
+
+- 2018-12-19 Initial version
+
+
+## Introduction
+
+The Intel(R) MKL-DNN team is planning to release **v1.0** of the library in
+mid-2019. With this major version change, we would like to clean up the API to
+make Intel MKL-DNN easier to use. For the future releases of v1.x series, we
+will preserve API and ABI backward compatibility according to
+[Semantic Versioning 2.0.0](https://semver.org/).
+
+This document describes user-visible and some important internal changes to
+help developers understand what to expect in the future. Appendix A shows
+the new C API types and functions (the C++ API is derived from the C API and
+hence omitted for brevity).
+
+The Intel MKL-DNN team would appreciate your feedback and suggestions on the
+given proposal! Feel free to post them in the PR created for this purpose.
+
+## Summary of changes
+
+We tried to keep changes minimal to make migration as simple as possible. In
+particular, the Intel MKL-DNN programming model would stay the same.
+Nevertheless, the new version would bring a lot of incompatible changes
+requiring developers to revisit significant portions of the integrated code.
+
+All changes can be split into the following groups:
+1. Removing already deprecated functionality
+2. Improving the library robustness
+3. Simplified execution model
+4. Changes in the view primitive
+5. Changes in memory description
+
+The first four groups of changes are discussed in detail in this document. The
+changes in the memory descriptor deserve a separate topic and are covered here
+only from a high-level perspective with detailed explanation available in the
+[RFC for memory descriptor](rfc_memory_desc.md).
+
+
+## 1. Remove deprecated functionality
+
+All the functionality that was marked as deprecated would be removed in v1.0.
+That actually already started happening. For instance, see
+[this](https://github.com/intel/mkl-dnn/commit/cb04a097c1e692f954702d02211defe986a3b65a)
+and
+[this](https://github.com/intel/mkl-dnn/commit/b7ab4a7b5985f98eb593cde9bdb7cee78f86bfa2)
+commits.
+
+| Deprecated functionality               | Replacement
+|:---                                    |:---
+| ReLU primitive                         | Eltwise with algorithm kind ReLU
+| ConvolutionReLU (single primitive)     | Convolution with ReLU as a post operation
+| Double precision scales                | Single precision scales
+| RNN backward pd w/o forward pd hint    | RNN backward pd w/ forward pd hint
+| `mkldnn_omit_stats` batch norm. flag   | `mkldnn_use_global_stats`
+| `mkldnn_eltwise_desc_t.negative_slope` | `mkldnn_eltwise_desc_t.alpha`
+
+The complete list of the deprecated C functions:
+``` c++
+    mkldnn_relu_forward_desc_init(...);
+    mkldnn_relu_backward_desc_init(...);
+    mkldnn_convolution_relu_desc_init(...);
+```
+
+The complete list of the deprecated C++ classes and functions:
+``` c++
+    struct mkldnn::convolution_relu_forward {}
+    struct mkldnn::relu_forward {}
+    struct mkldnn::relu_backward {}
+
+    mkldnn::sum::primitive_desc(const memory::desc &output, std::vector<double> scale, std::vector<memory::primitive_desc> inputs);
+    mkldnn::sum::primitive_desc(std::vector<double> scale, std::vector<memory::primitive_desc> inputs);
+    mkldnn::eltwise_forward::desc(prop_kind aprop_kind, const memory::desc &src_desc, T negative_slope);
+    mkldnn::eltwise_backward::desc(const memory::desc &diff_data_desc, const memory::desc &data_desc, T negative_slope);
+    rnn_backward::primitive_desc(const desc &desc, const engine &e);
+```
+
+### 1.1. Rename `foo_v2()` to `foo()` and remove old `foo()`
+
+The functions like:
+``` c++
+mkldnn_primitive_desc_create_v2(...);
+```
+would be renamed to:
+``` c++
+mkldnn_primitive_desc_create(...);
+```
+
+The old functions (`mkldnn_primitive_desc_create` in this example) would be
+removed.
+
+The current list of functions that have `_v2` suffix:
+
+``` c++
+mkldnn_primitive_desc_iterator_create_v2(...);
+mkldnn_primitive_desc_create_v2(...);
+mkldnn_reorder_primitive_desc_create_v2(...);
+```
+
+
+## 2. Improve the robustness
+
+### 2.1. The C++ API should take objects by reference whenever possible
+
+Currently there are several functions in the C++ API that take objects by value,
+which results in unnecessary copies. So for example `std::vector inputs` would
+be replaced with `std::vector &inputs`.
+
+### 2.2. Memory allocation in the C API
+
+In Intel MKL-DNN **v1.0**, constructing a memory object using the C API with no
+user-provided memory buffer would result in the buffer being allocated by the
+library. This would make the behavior of the C API memory constructor consistent
+with its C++ API `mkldnn::memory` counterpart, which allocates memory if called
+without a pointer to an existing memory buffer.
+
+### 2.3. Towards stateless primitives: explicit scratchpad management
+
+Currently Intel MKL-DNN primitives may allocate temporary **scratchpad**
+memory for storing intermediate computational results. For instance,
+convolution backward by weights typically requires extra space to perform a
+reduction of the `diff_weights` computed by different threads (the work is
+divided across images). Starting with **v1.0**, a new
+`mkldnn_query_scratchpad_mpd` query will return the amount of scratchpad
+memory needed for a primitive, and the user will be responsible for allocating
+and providing the scratchpad memory to a primitive at a runtime.
+
+> **WARNING** Scratchpad memory is not the same as workspace.
+>
+> Workspace is a memory that is passed from a forward pass to the
+> corresponding backward pass, e.g. from max pooling forward to max pooling
+> backward. Workspace keeps information required to compute results of the
+> backward pass. For max pooling, the workspace contains the indices where the
+> maximum was found. Workspace must be preserved between the forward and
+> backward call.
+>
+> In contrast, scratchpad memory is temporary: it is used only during a
+> primitive's computations (e.g. to perform a reduction across multiple
+> threads) and does not hold any useful data after the computations are done.
+> The only requirement for the scratchpad memory is that it should be
+> sufficiently large to store required data. The same scratchpad memory can be
+> reused in the next primitive provided the size requirements are met. That is
+> exactly what happens in most of the frameworks that manage all the memory on
+> their own.
+
+This change should make it possible to make Intel MKL-DNN primitives stateless
+and hence thread safe: the same primitive can be executed in multiple
+independent threads as long as different threads use different scratchpads.
+
+> **NOTE** Feedback requested
+>
+> We recognize that requiring the user to always pass scratchpad memory is an
+> intrusive change that may result in increased boilerplate code even for such
+> simple primitives as sum, concatenation, and reorder.
+>
+> As an option, Intel MKL-DNN could support the two following cases:
+> - if a user passes a scratchpad memory the primitive would use it;
+> - if a user does not pass a scratchpad memory the primitive would allocate a
+>   buffer for the execution time and use it as a scratchpad.
+>
+> In the latter case, a runtime allocation might affect performance but would
+> ensure functional correctness.
+>
+> It is not clear whether Intel MKL-DNN should support optional scratchpad. The
+> current plan is to not support it. This might be changed according to the
+> feedback received.
+
+
+## 3. Simplified execution model
+
+This is the most notable change in the library. The main idea is to change the
+execution API so that memory arguments are specified at a primitive
+execution time and not at the primitive creation time. This leads to the
+following changes.
+
+
+### 3.1. Memory is not a primitive anymore
+
+In the current API, memory has a type of primitive. With the new API, a memory
+would become a distinct data type. That would bring new data types and
+functions, such as:
+
+``` c++
+#define MKLDNN_NATIVE_HANDLE_ALLOCATE  ((void *)-1)
+#define MKLDNN_NATIVE_HANDLE_NONE      ((void *)0)
+
+struct mkldnn_memory_pd_t; // memory primitive descriptor type
+typedef const mkldnn_memory_pd_t const_mkldnn_memory_pd; // same, but const
+
+struct mkldnn_memory_t; // memory type, no more equal to mkldnn_primitive_t
+
+// create a memory primitive descriptor based on a memory descriptor
+mkldnn_status_t mkldnn_memory_primitive_desc_create(
+    mkldnn_memory_pd *mpd, const mkldnn_memory_desc_t *md,
+    mkldnn_engine_t engine);
+
+// create a memory
+// native_handle can:
+//  - point to the user allocated memory, i.e. valid handle. In this case the
+//    library doesn't own allocated memory.
+//  - be MKLDNN_NATIVE_HANDLE_ALLOCATE to ask the library to allocate and
+//    attach memory. In this case the library owns allocated memory.
+//  - be MKLDNN_NATIVE_HANDLE_NONE to create mkldnn_memory w/o attached memory.
+mkldnn_status_t mkldnn_memory_create(mkldnn_memory_t *mem,
+    const_mkldnn_memory_pd_t *mpd, void *native_handle);
+```
+
+
+### 3.2. Operation primitives cannot be used as inputs (use memory instead)
+
+The current API allows passing an operation primitive as an input to another
+primitive. For instance, a convolution primitive can be passed as an input to
+a consequent ReLU. During the execution the ReLU primitive queries the
+convolution for its output memory and uses it as an input.
+
+With the new API, users will be allowed to pass only memory type as inputs and
+outputs for primitives.
+
+
+### 3.3. Remove the `mkldnn_primitive_at_t` type
+
+Another consequence is that `mkldnn_primitive_at_t`, which is logically
+equivalent to `{primitive, output_index}`, becomes redundant. Previously the
+type was used to specify the exact memory to use (if a primitive has several
+outputs).
+
+
+### 3.4. Passing stream and input/output memories at primitive execution
+
+Finally, users would be able to directly run primitives by calling an `execute`
+function instead of putting primitives into a stream and running the latter.
+This change affects how primitives interact with streams and input/output
+memories: with the new API they become arguments to be passed to the primitive
+execution function.
+
+The change would significantly simplify primitive creation, which would now
+require a primitive descriptor only:
+
+```c++
+mkldnn_status_t mkldnn_primitive_create(mkldnn_primitive_t *primitive,
+    const_mkldnn_primitive_desc_t *pd);
+```
+
+To remove the ambiguity in which order input and output memories need to be
+passed, we introduce a map-like argument where each memory argument is paired
+with a tag indicating what kind of argument it is: destination, source,
+weights, and so on.
+
+``` c++
+// types
+#define MKLDNN_ARG_SRC_0 1
+#define MKLDNN_ARG_SRC   MKLDNN_ARG_SRC_0
+#define MKLDNN_ARG_FROM  MKLDNN_ARG_SRC_0
+// ...
+
+// C API
+typedef struct {
+    int arg; // MKLDNN_ARG_SRC, ...
+    mkldnn_memory_t memory;
+} mkldnn_exec_arg_t;
+
+mkldnn_status_t mkldnn_primitive_execute(mkldnn_primitive_t prim,
+    mkldnn_stream_t stream, int nargs, const mkldnn_exec_arg_t *args);
+
+// C++ API
+convolution_forward::execute(mkldnn::stream &stream,
+    const std::map<int, mkldnn::memory> &exec_args);
+// ... other primitives ...
+
+
+// example C, convolution forward w/ bias
+mkldnn_exec_arg_t conv_exec_args = {
+    {MKLDNN_ARG_SRC, src_mem},
+    {MKLDNN_ARG_WEIGHTS, weights_mem},
+    {MKLDNN_ARG_BIAS, bias_mem},
+    {MKLDNN_ARG_DST, dst_mem},
+};
+mkldnn_primitive_execute(conv_fwd, stream, 4, conv_exec_args);
+
+
+// example C++, in-place eltwise
+eltwise.execute(stream, {{MKLDNN_ARG_SRC, mem}, {MKLDNN_ARG_DST, mem}});
+```
+
+
+### 3.5 Short summary
+
+The example below shows conceptual code transformations between versions. The
+C++ API is used for brevity.
+
+Version 0.x:
+``` c++
+// create a convolution, specify all inputs and outputs
+auto conv = convolution(conv_pd,
+            {src_mem, 0}, {wei_mem, 0}, dst_conv_mem);
+
+// create a relu (note that one of inputs is the convolution)
+auto relu = relu(relu_pd,
+            {conv, 0}, dst_relu_mem);
+
+// create a stream, submit convolution and relu, and wait for the result
+stream().submit({conv, relu}).wait();
+```
+
+Version 1.x:
+``` c++
+// create convolution and relu. no inputs/outputs
+auto conv = convolution(conv_pd);
+auto relu = relu(relu_pd);
+
+// create stream (based on engine)
+stream s(engine, 0);
+
+// execute the convolution with given inputs, outputs
+conv.execute(s, {
+        {MKLDNN_ARG_SRC, src_mem},
+        {MKLDNN_ARG_WEIGHTS, wei_mem},
+        {MKLDNN_ARG_DST, dst_conv_mem}});
+
+// execute the relu. cannot pass convolution as an input, only memory is allowed
+relu.execute(s, {
+        {{MKLDNN_ARG_SRC, dst_conv_mem},
+        {MKLDNN_ARG_DST, dst_relu_mem}});
+
+s.wait(); // wait for async streams
+```
+
+
+## 4. View rework
+
+The current library API has a notion of view that, implementation-wise, is
+simply an alias for memory. This approach has a significant drawback: it is
+not possible to create a view for some combinations of memory formats, window
+sizes, and offsets. There is no way around this limitation other than
+reordering the original memory into a plain format (like `nchw`) and creating
+a view for the resulting memory. Obviously, this requires more memory and
+leads to suboptimal performance. Moreover, semantically it is not obvious that
+view might fail on creation even if all input parameters seem valid.
+
+Intel MKL-DNN **v1.0** will remove view and replace it with a set of
+auxiliary functions. The first one, given a memory descriptor, offsets, and
+window sizes, will create a memory descriptor that describes a part of the
+original memory. This function will not be guaranteed to always succeed.
+Semantics of this function will be very similar to the semantics of the
+currently available view primitive, but there will be no extra entities because
+it will operate on memory descriptors.
+
+In order to support cases when this function fails, two additional primitives
+will be provided to `extract` and `insert` data from/to a part of a memory.
+(Alternative names for `insert` and `extract` are `copyin` and `copyout`,
+respectively.) Semantically they are similar to reorders operating on parts
+of memory objects.
+
+For performance purposes, the preference should be given to creating a
+sub-memory.
+
+Several usage scenarios are shown below.
+
+###### Good scenario
+
+*For an experienced user who wants to do an in-place operation on a part of a
+memory:*
+
+```
+    a. User attempts to create a memory descriptor `md1`, based on the
+       original memory descriptor `md0`, offset, and size. This succeeds.
+    b. User passes `md1` to a primitive constructor. This guaranteed to
+       succeed, but may still fall back to a reference implementation (but
+       less frequently than in **Option 2**). User has to check...
+```
+
+###### Bad scenario
+
+*For an experienced user who wants to do a in-place operation on a part of a
+memory:*
+
+```
+    a. User attempts to create a memory descriptor `md1`, based on the
+       original memory descriptor `md0`, offset, and size. This fails.
+    b. User has to call an `extract` with the same `md0`, offset, and size to
+       a separate memory with memory descriptor `md1`.
+    c. User creates a primitive based on `md1`.
+```
+
+###### General scenario
+
+*Simple approach that always works:*
+
+```
+    a. User creates `extract` primitive with the input memory descriptor
+    `md0`, offset, and size, and output memory descriptor `md1`.
+    b. User creates a primitive using `md1`.
+```
+
+
+### 4.1 Sub-memory related API
+
+Both `extract` and `insert` are suggested to be regular primitives:
+
+``` c++
+// Inits memory descriptor for a submemory for given parent memory descriptor,
+// size, and offset.
+// This function may fail if submemory cannot be represented. In this case
+// use `extract` or `insert` primitives to operate with submemory.
+mkldnn_status_t mkldnn_memory_desc_init_submemory(
+        mkldnn_memory_desc_t *md, const mkldnn_memory_desc_t *parent_md,
+        const mkldnn_dims_t dims, const mkldnn_dims_t offset);
+
+typedef struct {
+    mkldnn_primitive_kind_t primitive_kind; // must be mkldnn_extract
+    mkldnn_prop_kind_t prop_kind;           // must be forward
+    mkldnn_memory_desc_t src_data_desc;     // parent descriptor
+    mkldnn_memory_desc_t dst_data_desc;     // dst_data_desc.fmt might be `any`
+    mkldnn_dims_t offset;
+} mkldnn_extract_desc_t;
+
+// Inits extract descriptor.
+// Memory format of `dst_d` might be `any`.
+mkldnn_status_t mkldnn_extract_desc_init(mkldnn_extract_desc_t *ed,
+        const mkldnn_memory_desc_t *src_d, const mkldnn_memory_desc_t *dst_d,
+        const mkldnn_dims_t offset);
+```
+
+Implementation for `insert` and / or `extract` might be postponed until a
+later release.
+
+
+## 5. Memory descriptor rework
+
+The current way of describing memory format has multiple issues. From the
+users' perspective, the main issues are:
+- Some memory formats are missing. For example, the `iohw` format is not
+  available.
+- There are multiple ambiguous ways to describe memory. For example, `oihw`
+  describes memory in the same way as `nchw`, but these formats are different
+  (see gh#153).
+- Support for custom formats is limited.
+- Support for memory views is limited.
+
+There are more substantial issues from the library development perspective:
+code bloat to support special cases, etc.
+
+We address the issues above by reworking memory descriptors. From the user
+perspective, the main changes are:
+1. Memory descriptors will support arbitrary strides for plain layouts. For
+   example, initializing a memory descriptor with `strides={h*w, o*h*w, w, 1}`
+   should be a valid way to define `iohw` format even if Intel MKL-DNN does
+   not support it explicitly.
+2. Dimensions will be of type `int64_t` instead of int and the maximum number
+   of tensor dimensions will be decreased from 16 to 12.
+3. The `memory_desc_t.format` field will be replaced with
+   `memory_desc_t.format_kind`, which will also have different semantics.
+
+While the first two items are self-explanatory, the last one requires some
+additional elaboration.
+
+Currently, most memory formats can be described directly by using appropriate
+format names (for example, `nchw`) that fully describe how data is laid out in
+memory. However, Intel MKL-DNN also has the `blocked` memory format and the
+corresponding `memory_desc_t.layout_desc.blocking_desc` structure, which can
+describe a memory format in a unified fashion by specifying block sizes and
+strides. The original idea was to used format names like `nchw` during memory
+descriptor initialization only, and always use the `blocked` format internally.
+Unfortunately, that was never implemented.
+
+With the new design, Intel MKL-DNN will start distinguishing between the actual
+memory format and convenience memory format names that can be used to describe
+memory format concisely.
+
+Users will still be able to initialize memory descriptors with format names
+like `nchw`, but the `memory_desc_t.format_kind` will be set to a canonicalized
+kind like `blocked`, and the format name will not be recorded in the memory
+descriptor structure. Initialization with strides will always result in
+`blocked` format. The API will also use different types for memory format
+names and kind to aid correctness.
+
+This change affects all existing code. For more details, refer to the
+[RFC for memory descriptor](rfc_memory_desc.md) document.
+
+
+## Appendix A. Changes in C API
+
+See [c_api.h](c_api.h).
+
+
+###### End of document

--- a/doc/rfc/api-v1.0/README.md
+++ b/doc/rfc/api-v1.0/README.md
@@ -11,7 +11,6 @@
              Minor clean ups;
 - 2019-04-20 [v1.0 Preview Candidate 2](https://github.com/intel/mkl-dnn/releases/tag/v1.0-pc2) is published;
              Introduced support for Intel(R) Processor Graphics;
-             
 
 
 ## Introduction
@@ -282,7 +281,7 @@ convolution_forward::execute(mkldnn::stream &stream,
 
 
 // example C, convolution forward w/ bias
-mkldnn_exec_arg_t conv_exec_args = {
+mkldnn_exec_arg_t conv_exec_args[] = {
     {MKLDNN_ARG_SRC, src_mem},
     {MKLDNN_ARG_WEIGHTS, weights_mem},
     {MKLDNN_ARG_BIAS, bias_mem},

--- a/doc/rfc/api-v1.0/c_api.h
+++ b/doc/rfc/api-v1.0/c_api.h
@@ -12,32 +12,32 @@ typedef int64_t dims_t[MKLDNN_MAX_NDIMS];
 // enum that helps to specify the memory format
 // (used in auxiliary functions only)
 typedef enum {
-    mkldnn_mf_any,      // special indicator
+    mkldnn_format_tag_any,      // special indicator
 
-    mkldnn_mf_a,
-    mkldnn_mf_ab,
-    mkldnn_mf_ba,
+    mkldnn_a,
+    mkldnn_ab,
+    mkldnn_ba,
     //...
-    mkldnn_mf_abcd,     // corresponds to nchw, oihw
-    mkldnn_mf_acdb,     // corresponds to nhwc, ohwi
+    mkldnn_abcd,     // corresponds to nchw, oihw
+    mkldnn_acdb,     // corresponds to nhwc, ohwi
     // ...
-    mkldnn_mf_aBcd16b,  // corresponds to nChw16c, oIhw16c
+    mkldnn_aBcd16b,  // corresponds to nChw16c, oIhw16c
     // ...
 
     // aliases below
-    mkldnn_mf_nchw = mkldnn_mf_abcd,
-    mkldnn_mf_oihw = mkldnn_mf_abcd,
-    mkldnn_mf_nChw16c = mkldnn_mf_aBcd16b,
+    mkldnn_nchw = mkldnn_abcd,
+    mkldnn_oihw = mkldnn_abcd,
+    mkldnn_nChw16c = mkldnn_aBcd16b,
     // ...
-} mkldnn_mememory_format_t;
+} mkldnn_format_tag_t;
 
 // enum that identifies how data is described in memory descriptor, i.e. at
 // what field to look at in memory_desc_t.format_desc union.
 typedef enum {
-    mkldnn_mfdi_undef,
-    mkldnn_mfdi_any,
-    mkldnn_mfdi_blocked,
-    mkldnn_mfdi_wino,
+    mkldnn_format_kind_undef,
+    mkldnn_format_kind_any,
+    mkldnn_blocked,
+    mkldnn_format_kind_wino,
 } mkldnn_memory_format_kind_t
 
 // new blocking structure that handles double+ blocking
@@ -174,8 +174,8 @@ typedef struct {
 
 typedef enum {
     // ...
-    mkldnn_query_workspace_mpd,  /**< workspace memory primitive desc */
-    mkldnn_query_scratchpad_mpd, /**< scratchpad memory primitive desc */
+    mkldnn_query_workspace_md,  /**< workspace memory primitive desc */
+    mkldnn_query_scratchpad_md, /**< scratchpad memory primitive desc */
 } mkldnn_query_t;
 
 
@@ -192,14 +192,9 @@ mkldnn_memory_desc_init_by_strides(mkldnn_memory_desc_t *md,
 
 // inits memory desc for the given dims and memory format
 // for those who is used to the previous versions
-mkldnn_memory_desc_init_by_format(mkldnn_memory_desc_t *md,
-        int ndims, const dims_t dims, mkldnn_memory_format_t format,
+mkldnn_memory_desc_init_by_tag(mkldnn_memory_desc_t *md,
+        int ndims, const dims_t dims, mkldnn_format_tag_t tag,
         mkldnn_data_type_t data_type);
-
-// creates a memory primitive descriptor based on a memory descriptor
-mkldnn_status_t mkldnn_memory_primitive_desc_create(
-    mkldnn_memory_pd *mpd, const mkldnn_memory_desc_t *md,
-    mkldnn_engine_t engine);
 
 // creates a memory
 // native_handle can:
@@ -208,8 +203,8 @@ mkldnn_status_t mkldnn_memory_primitive_desc_create(
 //  - be MKLDNN_NATIVE_HANDLE_ALLOCATE to ask the library to allocate and
 //    attach memory. In this case the library owns allocated memory.
 //  - be MKLDNN_NATIVE_HANDLE_NONE to create mkldnn_memory w/o attached memory.
-mkldnn_status_t mkldnn_memory_create(mkldnn_memory_t *mem,
-        const_mkldnn_memory_pd_t *mpd, void *native_handle);
+mkldnn_status_t mkldnn_memory_create(mkldnn_memory_t *memory,
+    const mkldnn_memory_dest_t *md, mkldnn_engine_t engine, void *handle);
 
 // attaches a native handle to memory
 // perform_zero_padding is flag that indicates whether the library should

--- a/doc/rfc/api-v1.0/c_api.h
+++ b/doc/rfc/api-v1.0/c_api.h
@@ -1,0 +1,228 @@
+/*
+ * mkldnn_types.h
+ *
+ * NOTE: in some places `mkldnn_` prefix is omitted to simplify reading.
+ */
+
+#define MKLDNN_MAX_NDIMS 12 // previously 16, 12 should be enough
+
+// previously typeof(dims_t[0]) == int, now ptrdiff_t to handle big 1D tensors
+typedef int64_t dims_t[MKLDNN_MAX_NDIMS];
+
+// enum that helps to specify the memory format
+// (used in auxiliary functions only)
+typedef enum {
+    mkldnn_mf_any,      // special indicator
+
+    mkldnn_mf_a,
+    mkldnn_mf_ab,
+    mkldnn_mf_ba,
+    //...
+    mkldnn_mf_abcd,     // corresponds to nchw, oihw
+    mkldnn_mf_acdb,     // corresponds to nhwc, ohwi
+    // ...
+    mkldnn_mf_aBcd16b,  // corresponds to nChw16c, oIhw16c
+    // ...
+
+    // aliases below
+    mkldnn_mf_nchw = mkldnn_mf_abcd,
+    mkldnn_mf_oihw = mkldnn_mf_abcd,
+    mkldnn_mf_nChw16c = mkldnn_mf_aBcd16b,
+    // ...
+} mkldnn_mememory_format_t;
+
+// enum that identifies how data is described in memory descriptor, i.e. at
+// what field to look at in memory_desc_t.format_desc union.
+typedef enum {
+    mkldnn_mfdi_undef,
+    mkldnn_mfdi_any,
+    mkldnn_mfdi_blocked,
+    mkldnn_mfdi_wino,
+} mkldnn_memory_format_kind_t
+
+// new blocking structure that handles double+ blocking
+typedef struct {
+    dims_t strides;     // the strides between the *major* dimensions, i.e.
+                        // between `O`, `I`, `h`, and `w`, in `OIhw4i16o4i`
+
+    // tail section.
+    // ASSUMPTION: the tail is always dense, unlike the *major* dimensions
+    int tail_nblks;     // number of tail blocks, e.g. 3 in case OIhw_4i16o4i_
+    dims_t tail_blks;   // the size of blocks, {4, 16, 4} in case OIhw4i16o4i
+    dims_t tail_idxs;   // the logical indices of the tail blocks, e.g.
+                        // {1, 0, 1} in case of 4i16o4i, because `i` is 1st dim
+                        // and `o` is 0st dim
+} blocking_desc_t;
+
+// structure that holds *extra* information
+typedef struct {
+    // flags contain arbitrary extra info, such as compensation, e.g.:
+    // - MKLDNN_MDEF_NONE (0u)
+    // - MKLDNN_MDEF_COMP_CONV_S8S8 (1u) - tensor contains compensation
+    //                                     information (along what dim?)
+    // - MKLDNN_MDEF_ADJ_SCALE (2u) - tensor is adjusted by the given value
+    //                                (used in s8s8-conv and wino2x3)
+    uint64_t flags;     // flags contain arbitrary extra info,
+                        // such as compensation
+    float scale_adjust; // scale applied to the data (used on SKX)
+    char reserved[64];  // for future backwards compatibility
+} mkldnn_md_extra_t;
+
+// reworked memory_desc_t
+typedef struct {
+    // logical description of the tensor
+    int ndims;              // number of logical dimension
+    dims_t dims;            // the dimensions themselves
+    data_type_t data_type;  // (main) data type
+
+    // information about padded dimensions
+    dims_t padded_dims;     // the dimensions of the parent tensor incl. padding
+    dims_t padded_offsets;  // the offsets of parent tensor with padded tensor
+
+    // basic offset (useful in the cases when there is no pointer arithmetic)
+    ptrdiff_t offset0;      // to access the first element of the padded
+                            // tensor, one should dereference ptr + offset0
+
+    // physical description
+    memory_format_kind_t format_kind; // { undef, any, blocking, wino }
+    union {
+        blocking_desc_t;    // must be able to handle double+ blocking
+        wino_desc_t;
+    } format_desc;
+
+    // section with *extra* information
+    mkldnn_md_extra_t extra;
+} mkldnn_memory_desc_t;
+
+
+#define MKLDNN_NATIVE_HANDLE_ALLOCATE  ((void *)-1)
+#define MKLDNN_NATIVE_HANDLE_NONE      ((void *)0)
+
+struct mkldnn_memory_pd_t; // previous primitive descriptor
+typedef const mkldnn_memory_pd_t const_mkldnn_memory_pd;
+
+struct mkldnn_memory_t; // previously primitive
+
+
+// ...
+
+#define MKLDNN_ARG_SRC_0                1
+#define MKLDNN_ARG_SRC                  MKLDNN_ARG_SRC_0
+#define MKLDNN_ARG_SRC_LAYER            MKLDNN_ARG_SRC_0
+
+#define MKLDNN_ARG_SRC_1                2
+#define MKLDNN_ARG_SRC_ITER             MKLDNN_ARG_SRC_1
+
+#define MKLDNN_ARG_DST_0                17
+#define MKLDNN_ARG_DST                  MKLDNN_ARG_DST_0
+#define MKLDNN_ARG_TO                   MKLDNN_ARG_DST_0
+#define MKLDNN_ARG_DST_LAYER            MKLDNN_ARG_DST_0
+
+#define MKLDNN_ARG_DST_1                18
+#define MKLDNN_ARG_DST_ITER             MKLDNN_ARG_DST_1
+
+#define MKLDNN_ARG_WEIGHTS_0            33
+#define MKLDNN_ARG_WEIGHTS              MKLDNN_ARG_WEIGHTS_0
+#define MKLDNN_ARG_SCALE_SHIFT          MKLDNN_ARG_WEIGHTS_0
+#define MKLDNN_ARG_WEIGHTS_LAYER        MKLDNN_ARG_WEIGHTS_0
+
+#define MKLDNN_ARG_WEIGHTS_1            34
+#define MKLDNN_ARG_BIAS                 MKLDNN_ARG_WEIGHTS_1
+#define MKLDNN_ARG_WEIGHTS_ITER         MKLDNN_ARG_WEIGHTS_1
+
+#define MKLDNN_ARG_MEAN                 49
+#define MKLDNN_ARG_VARIANCE             50
+
+#define MKLDNN_ARG_WORKSPACE            64
+#define MKLDNN_ARG_SCRATCHPAD           80
+
+#define MKLDNN_ARG_DIFF_SRC_0           129
+#define MKLDNN_ARG_DIFF_SRC             MKLDNN_ARG_DIFF_SRC_0
+#define MKLDNN_ARG_DIFF_SRC_LAYER       MKLDNN_ARG_DIFF_SRC_0
+
+#define MKLDNN_ARG_DIFF_SRC_1           130
+#define MKLDNN_ARG_DIFF_SRC_ITER        MKLDNN_ARG_DIFF_SRC_1
+
+#define MKLDNN_ARG_DIFF_DST_0           145
+#define MKLDNN_ARG_DIFF_DST             MKLDNN_ARG_DIFF_DST_0
+#define MKLDNN_ARG_DIFF_DST_LAYER       MKLDNN_ARG_DIFF_DST_0
+
+#define MKLDNN_ARG_DIFF_DST_1           146
+#define MKLDNN_ARG_DIFF_DST_ITER        MKLDNN_ARG_DIFF_DST_1
+
+#define MKLDNN_ARG_DIFF_WEIGHTS_0       161
+#define MKLDNN_ARG_DIFF_WEIGHTS         MKLDNN_ARG_DIFF_WEIGHTS_0
+#define MKLDNN_ARG_DIFF_SCALE_SHIFT     MKLDNN_ARG_DIFF_WEIGHTS_0
+#define MKLDNN_ARG_DIFF_WEIGHTS_LAYER   MKLDNN_ARG_DIFF_WEIGHTS_0
+
+#define MKLDNN_ARG_DIFF_WEIGHTS_1       162
+#define MKLDNN_ARG_DIFF_BIAS            MKLDNN_ARG_DIFF_WEIGHTS_1
+#define MKLDNN_ARG_DIFF_WEIGHTS_ITER    MKLDNN_ARG_DIFF_WEIGHTS_1
+
+#define MKLDNN_ARG_MULTIPLE_SRC         1024
+#define MKLDNN_ARG_MULTIPLE_DST         2048
+
+// describes an argument
+typedef struct {
+    int arg; // MKLDNN_ARG_SRC, ...
+    mkldnn_memory_t memory;
+} mkldnn_exec_arg_t;
+
+
+// ...
+
+
+typedef enum {
+    // ...
+    mkldnn_query_workspace_mpd,  /**< workspace memory primitive desc */
+    mkldnn_query_scratchpad_mpd, /**< scratchpad memory primitive desc */
+} mkldnn_query_t;
+
+
+
+
+/*
+ * mkldnn.h
+ */
+
+// inits memory desc for the given dims and strides between them
+mkldnn_memory_desc_init_by_strides(mkldnn_memory_desc_t *md,
+        int ndims, const dims_t dims, const dims_t strides,
+        mkldnn_data_type_t data_type);
+
+// inits memory desc for the given dims and memory format
+// for those who is used to the previous versions
+mkldnn_memory_desc_init_by_format(mkldnn_memory_desc_t *md,
+        int ndims, const dims_t dims, mkldnn_memory_format_t format,
+        mkldnn_data_type_t data_type);
+
+// creates a memory primitive descriptor based on a memory descriptor
+mkldnn_status_t mkldnn_memory_primitive_desc_create(
+    mkldnn_memory_pd *mpd, const mkldnn_memory_desc_t *md,
+    mkldnn_engine_t engine);
+
+// creates a memory
+// native_handle can:
+//  - point to the user allocated memory, i.e. valid handle. In this case the
+//    library doesn't own allocated memory.
+//  - be MKLDNN_NATIVE_HANDLE_ALLOCATE to ask the library to allocate and
+//    attach memory. In this case the library owns allocated memory.
+//  - be MKLDNN_NATIVE_HANDLE_NONE to create mkldnn_memory w/o attached memory.
+mkldnn_status_t mkldnn_memory_create(mkldnn_memory_t *mem,
+        const_mkldnn_memory_pd_t *mpd, void *native_handle);
+
+// attaches a native handle to memory
+// perform_zero_padding is flag that indicates whether the library should
+// zero pad the padded area (if any). It is recommended to always pass 1 (true)
+// to have a consistent memory (i.e. memory that corresponds to the memory
+// descriptor structure).
+mkldnn_status_t mkldnn_memory_set_data_handle(mkldnn_memory_t *mem,
+        void *handle, int perform_zero_padding);
+
+// creates a primitive based on a primitive descriptor. no input/outputs
+mkldnn_status_t mkldnn_primitive_create(mkldnn_primitive_t *primitive,
+        const_mkldnn_primitive_desc_t *pd);
+
+// executes primitive on a given stream and given set of inputs and outputs
+mkldnn_status_t mkldnn_primitive_exec(mkldnn_primitive_t prim,
+        mkldnn_stream_t stream, int nargs, const mkldnn_exec_arg_t *args);

--- a/doc/rfc/api-v1.0/rfc_memory_desc.md
+++ b/doc/rfc/api-v1.0/rfc_memory_desc.md
@@ -1,0 +1,452 @@
+# [RFC] Memory descriptor
+
+## 0. About this document
+
+This document describes suggested changes for the memory descriptor structure
+that address several significant issues with the current approach.
+
+The changes can be split into two categories:
+- changes in the physical description that remove named formats;
+- changes in the compensation description used, for example, for
+  s8s8-convolutions.
+
+
+## 1. Introduction
+
+There are two main problems with the current memory description:
+- Multi-level blocking cannot be described by the structure itself
+  (current workaround is to use named formats).
+- Compensation cannot be described by the structure itself
+  (same workaround currently -- named formats).
+
+There are a few other problems, mainly caused by named formats:
+- Named formats lead to doubling of the number of the formats (and reorders)
+  whenever a new format kind is added. For example adding a format for
+  deconvolution that requires swapping the `o` and `i` dimensions leads to
+  duplicating all double-blocked named formats (regular layouts can be
+  replaced with `blocked` with swapped `o` and `i` entries).
+- There is ambiguity in physical format description. The same physical format
+  can be directly named (e.g. `nChw16c`) or be called `blocked` with identical
+  blocking structure.
+- There is no clear definition of named formats. For instance, for the format
+  `nchw` it is not clear whether the tensor must be dense or may have
+  non-trivial strides. If arbitrary strides are allowed, it is not clear what
+  is the difference between `nchw` versus `nhwc` (assuming the strides are the
+  same). This *duality* is misleading for the users and error-prone for the
+  developers.
+- No optimized primitives support non-trivial strides because they assume
+  that the named format is dense or leads to dense structure, nor do they
+  support the `blocked` layout format even if the physical structure describes
+  exactly the dense `nChw16`. One consequence is that `view` is not supported
+  on the primitive level; that is, there is no sense in creating convolution on
+  viewed memory because Intel(R) MKL-DNN  would currently always fall back to a
+  reference implementation even though the code itself may easily support
+  some of the `view`s.
+
+To resolve these issues, a new memory description is proposed (currently this
+is just a concept to be finalized later):
+
+``` c++
+#define MKLDNN_MAX_NDIMS 12 // previously 16, 12 should be enough
+
+// previously typeof(dims_t[0]) == int, now ptrdiff_t to handle big 1D tensors
+typedef ptrdiff_t dims_t[MKLDNN_MAX_NDIMS];
+
+typedef struct {
+    // logical description of the tensor
+    int ndims;              // number of logical dimension
+    dims_t dims;            // the dimensions themselves
+    data_type_t data_type;  // (main) data type
+
+    // information about padded dimensions
+    dims_t padded_dims;     // the dimensions of the parent tensor incl. padding
+    dims_t padded_offsets;  // the offsets of parent tensor with padded tensor
+
+    // basic offset (useful in the cases when there is no pointer arithmetic)
+    ptrdiff_t offset0;      // to access the first element of the padded
+                            // tensor, one should dereference ptr + offset0
+
+    // physical description
+    format_kind_t format_kind;  // { undef, any, blocking, wino }
+    union {
+        blocking_desc_t;    // must be able to handle multi-level blocking
+        wino_desc_t;
+    } format_desc;
+
+    // section with *extra* information
+    struct {
+        uint64_t flags;     // flags contain arbitrary extra info,
+                            // such as compensation
+        float scale_adjust; // scale applied to the data (used on SKX)
+        char reserved[64];  // for future backwards compatibility
+    } extra;
+} mkldnn_memory_desc_t;
+```
+
+The details are covered in the subsequent sections.
+
+
+## 2. You can(not) avoid named formats
+
+Blocking descriptor is changed so that it allows describing structure with
+multi-level blocking. Named formats (such as `nchw`, `OIhw4i16o4i`) are no
+longer used to define formats; common `mkldnn_blocked` should be used instead.
+
+However, getting rid of named formats completely doesn't seem feasible:
+- users need to express what format they use;
+- the code internally uses named formats extensively (e.g. to set a memory
+  descriptor from `any` to `nChw16c`), because this is convenient;
+- for testing purposes: for instance, **benchdnn** can test batch normalization
+  on a given format. Hence there should be a (convenient) way to set the
+  format for testing.
+
+Hence the idea is to separate the formats names and format kinds that specify
+which structure is used for physical layout description. Format names would
+still be of type `mkldnn_memory_format_t` while the kind would be of type
+`mkldnn_memory_format_kind_t`. The latter can be only `{undef, any, blocked,
+wino}`.
+
+Named formats are used only to fill in the blocking structure, keeping the
+`md.format_kind` equal to `mkldnn_blocked`.
+
+Hereafter named formats would be called either *formats* or *named formats* and
+refer to the `mkldnn_memory_format_t` type. The memory format kind that is used
+in memory descriptor structure would be called *memory format kind*, or
+*format kind* for short.
+
+It is also important to remove any semantics that a former named format gave to
+a tensor (for example, `nchw` implied that the tensor is data, while `oihw` is
+used for weights; though for both named formats the blocking structure is filled
+the same). To achieve this effect, we would use dimension-agnostic letters, such
+as `a`, `b`, `c`, ... So `nchw` would be the same as `oihw`, and both would be
+aliases to an abstract `abcd`. Similar, `nChw16c` and `oIhw16i` would be aliases
+to `aBcd16b`.
+
+``` c++
+typedef enum {
+    mkldnn_a,
+    mkldnn_ab,
+    mkldnn_ba,
+    //...
+    mkldnn_abcd,     // corresponds to nchw, oihw
+    mkldnn_acdb,     // corresponds to nhwc, ohwi
+    // ...
+    mkldnn_aBcd16b,  // corresponds to nChw16c, oIhw16c
+    // ...
+    mkldnn_nchw = mkldnn_abcd,
+    mkldnn_nChw16c = mkldnn_aBcd16b,
+    // ...
+} mkldnn_memory_format_t;
+```
+
+Previously, formats were used to allow the user to create Intel MKL-DNN memory.
+With the new API, users would have two ways to describe their memory layout: the
+generic one that takes the dimensions and strides between them (close to what
+Intel MKL had), and another one that would be really close to the original
+`mkldnn_memory_desc_init`, which takes dimensions and named memory format.
+
+``` c++
+// inits memory desc for the given dims and strides between them
+mkldnn_memory_desc_init_by_strides(mkldnn_memory_desc_t *md,
+        int ndims, const dims_t dims, const dims_t strides,
+        data_type_t data_type);
+
+// inits memory desc for the given dims and memory format
+// for those who is used to the previous versions
+mkldnn_memory_desc_init_by_format(mkldnn_memory_desc_t *md,
+        int ndims, const dims_t dims, mkldnn_memory_format_t format,
+        data_type_t data_type);
+```
+
+See additional discussion of usage of named format after the next section, which
+introduces the new blocking structure.
+
+
+## 3. New blocking descriptor (for multi-level blocking)
+
+*So far there is no good known solution...*
+
+But the interim thought is to focus on the description of innermost blocks,
+allowing outer blocks to have arbitrary strides. The blocking structure might
+then look like:
+
+``` c++
+typedef struct {
+    dims_t strides;     // the strides between the *major* dimensions, i.e.
+                        // between `O`, `I`, `h`, and `w`, in `OIhw4i16o4i`
+
+    // innermost section.
+    // ASSUMPTION: the innermost blocks are always dense, unlike the *major* dimensions
+    int inner_nblks;    // number of innermost blocks, e.g. 3 in case OIhw_4i16o4i_
+    dims_t inner_blks;  // the size of blocks, {4, 16, 4} in case OIhw4i16o4i
+    dims_t inner_idxs;  // the logical indices of the innermost blocks, e.g.
+                        // {1, 0, 1} in case of 4i16o4i, because `i` is 1st dim
+                        // and `o` is 0st dim
+} blocking_desc_t;
+```
+
+There is a very important assumption that is applied along with the structure:
+the innermost blocks are **always** dense. The *major* dimensions are allowed to have
+arbitrary strides. That means if a convolution implementation works with
+`nChw16c` format and it is really important that only `Chw16c` is dense while
+`n` might have arbitrary stride, this implementation should check that:
+
+``` c++
+auto &bd = data_md.format_desc.blocking_desc;
+book ok = true
+    && bd.inner_nblks == 1
+    && bd.inner_blks[0] == 16
+    && bd.inner_idxs[0] == 1     // c is the dim with index 1
+    && bd.strides[3] == 16       // stride for `w`
+    && bd.strides[2] == bd.strides[3] * 16
+    && bd.strides[1] == bd.strides[2] * md.dims[2];
+    // bd.strides[0] might be whatever
+
+    if (!ok) return unimplemented; // unsupported memory format
+```
+
+> **NOTE**
+>
+> There are many open questions regarding the suggested structure. One of them
+> is more about details: for example, is it better to have `inner_blks` or to
+> have the cumulative sizes (e.g. `{4*16*4, 16*4, 4}` instead of `{4, 16, 4}`)?
+> Or is it better to keep the dimension in reverse order (at least for the
+> innermost blocks)?
+
+The proposed blocking descriptor restrictions:
+- As already mentioned above, the innermost blocks must be dense.
+- The blocks for a given dimension lie in order; that is, the elements with
+  lower indices always appear before the elements with higher indices.
+- One should parse the description of innermost blocks completely to identify
+  the *major* dimensions; for example, it is not that easy to understand that
+  `I` equals `i / 16` in `OIhw4i16o4i`, because this `16 = 4 * 4` is **not**
+  explicitly written anywhere.
+- The (minor) number of innermost blocks must be 12 or less.
+
+### New blocking descriptor and named formats
+
+As already mentioned above, a complete removal of named format seems illogical.
+Intel MKL-DNN developers and users currently use named format in the following
+situations:
+
+- Users and tests use them to describe the format of the data they have.
+
+The replacements for `mkldnn_memory_desc_init()` were already mentioned.
+In most of the cases users can use `mkldnn_memory_desc_init_by_strides()` to
+create memory descriptors with plain formats. Alternatively, we allow them to
+directly use `mkldnn_memory_desc_init_by_format()` to define the layout by
+named format, including the blocked one (like `nChw16c`). Ideally users should
+not need to create memory in blocked format, although that may happen sometimes
+(for example, see the Intel MKL-DNN integration in TensorFlow). Sometimes that
+is done by Intel MKL-DNN tests as well (for example, benchdnn), so this
+functionality seems useful.
+
+- Convolution primitives use them to specify the format they want if the user
+  specifies format `any`.
+
+Currently Intel MKL-DNN has
+``` c++
+memory_primitive_desc_t::set_format(memory_format_t fmt)
+```
+method that specifies the memory descriptor structure based on the input
+format. The replacement of that code would be:
+``` c++
+memory_primitive_desc_t::set_by_format(memory_format_t format,
+        const dims_t strides = nullptr)
+```
+which does the same but also supports arbitrary strides for the *major*
+dimensions. It is not clear how useful it is to have the `strides` parameter,
+but for RNN it may be used to set a good leading dimension.
+
+Note that if `strides` are not specified, the `format` is used to define the
+strides for *major* dimensions (assuming dense data layout). However, if a
+developer provides the `strides`, the `format` is used to fill the innermost
+part of the blocking structure only.
+
+- Convolution and other primitives to check whether provided format is supported.
+
+That is the weakest point of the current Intel MKL-DNN, because currently the
+format is checked by name.  For example:
+
+``` c++
+    bool ok = src_md.format == mkldnn_nChw16c;
+```
+
+This code doesn't cover the case when the data layout corresponds to
+`nChw16c` but the name of the format is `blocked`. For this legitimate case
+the implementation would fail.
+
+Another problem is that if `C` or `h` have non-trivial strides,
+implementations do not check that, and most likely primitives would
+compute an incorrect result.
+
+The suggested replacement for the code above is:
+
+``` c++
+    // returns true if memory desc `md` corresponds to the given named format
+    // (optionally) there might be provided strides for *major* dimensions
+    // in which case the strides are also checked (value `-1` ignored).
+    bool memory_desc_matches_format(const memory_desc_t *md,
+            memory_format_t format, const dims_t strides = nullptr);
+
+
+    // example 1: an implementation works strictly with dense format `nChw8c`
+    bool ok = memory_desc_matches_format(&src_md, mkldnn_mft_aBcd8b, nullptr);
+
+    // example 2: an implementation works with `nChw8c` where `Chw8c` must be
+    //            dense, while `n` might have an arbitrary stride
+    const int c = src_md.dims[1], h = src_md.dims[2], w = src_md.dims[3];
+    bool ok = memory_desc_matches_format(&src_md, mkldnn_mft_aBcd8b,
+            {-1, h * w * 8, w * 8, 8});
+```
+
+> Suggestions on better names and internal API are very welcome.
+
+In particular, this approach allows supporting views and even in-place
+concat (though that requires some really skillful and inconvenient manipulations
+with primitive creation).
+
+- Non-JIT-ed reorder is template-ized by named memory format to implement
+  reorders from plain to blocked formats with padded area.
+
+There are multiple ways to port this code. One is to try to keep the current
+structure with named formats. The biggest concern for this approach is that
+that would require introducing the same format as we have now. However since
+new named formats don't have the semantics of the memory, the following
+traits would become impossible:
+
+``` c++
+template <> struct format_traits<...> {
+{
+    constexpr data_kind_t data_kind; // data, wei, gwei, rnn
+    constexpr int         ndims_sp;  // # of spatial dimensions
+};
+```
+
+Missing those features might complicate the code in `cpu/simple_reorder.hpp`.
+
+Another approach to implement the reorders is to somehow instantiate them using
+innermost blocking indices. There are 10 different index sequences:
+
+```
+    {0},    // Oihw8o, Oihw16o, ...
+    {1},    // nChw16c, gOihw8o, ...
+
+    {0, 1}, // OIhw16o16i, ...
+    {1, 0}, // OIhw16i16o, ...
+    {1, 2}, // gOIhw16o16i, ...
+    {2, 1}, // gOIhw16i16o, ...
+
+    {1, 0, 1}, // OIhw4i16o4i, ...
+    {0, 1, 0}, // OIhw4o16i4o, ...
+    {2, 1, 2}, // gOIhw4i16o4i, ...
+    {1, 2, 1}, // gOIhw4o16i4o, ...
+```
+
+Then for any given sequence, write the corresponding reorder code:
+
+```
+    // assuming inner_idxs = {0, 1}
+    int Ba = md.blocking_desc.inner_blks[0];
+    int Bb = md.blocking_desc.inner_blks[1];
+
+    int c = dims > 1 ? md.dims[2] : 1;
+    int d = dims > 2 ? md.dims[3] : 1;
+    int e = dims > 3 ? md.dims[4] : 1;
+
+    for (_a = 0 .. a / Ba)
+    for (_b = 0 .. b / Ba)
+    for (_c = 0 .. c)
+    for (_d = 0 .. d)
+    for (_e = 0 .. e)
+    {
+        for (_Ba = 0 .. Ba)
+        for (_Bb = 0 .. Bb)
+            dst[...] = src[...];
+    }
+```
+
+Alas, with this approach the compiler has very little information: even the
+block size is not known at compile time. However we will have fewer functions to
+instantiate (which will reduce the compile time).
+
+The same issue would occur with `memory::set_zero()`.
+
+
+### Pitfalls of the new blocking descriptor
+
+This section will be expanded later with a discussion of the complexity of
+implementations of:
+- `md::l_off(...)` // will be (much) slower than what we have now
+- compiler-optimized reorders // ~10 types of those
+- `memory::set_zero()` // ~10 type of those
+
+
+## 4. Compensation
+
+Having compensation as a first-class citizen (along with the blocking
+structure) is essential for moving to a named-format free paradigm. Currently
+we embed the knowledge about the compensation into the format name (for example,
+`hwigo_s8s8`).
+
+Since the proposal is to have very few format ids (`undef`, `any`, `blocked`,
+and `wino`), we need to put the information about the compensation somewhere
+else. That's exactly why we need an `extra` field in the memory descriptor.
+
+``` c++
+typedef struct {
+    // flags contain arbitrary extra info, such as compensation, e.g.:
+    // - MKLDNN_MDEF_NONE (0u)
+    // - MKLDNN_MDEF_COMP_CONV_S8S8 (1u) - tensor contains compensation
+    //                                     information (along what dim?)
+    // - MKLDNN_MDEF_ADJ_SCALE (2u) - tensor is adjusted by the given value
+    //                                (used in s8s8-conv and wino2x3)
+    // - MKLDNN_MDEF_Q10N_PARAMS (?) - maybe somewhere in the distant future
+    //                                 (that would mean scale and shift are
+    //                                 kept right after the values)...
+    uint64_t flags;
+    float scale_adjust;
+    char reserved[64];  // for future backwards compatibility
+} mkldnn_md_extra_t;
+
+struct mkldnn_memory_desc_t {
+    // ...
+    mkldnn_md_extra_t extra;
+};
+```
+
+It seems we don't need to put a lot of information into this `extra` part.
+The flags that would identify different kinds of compensations (e.g. int8
+convolution, int8 RNN, something else) should be enough.
+
+One more thing that makes sense to put in `extra` is `scale_adjust`, which is
+used on SKX for int8 convolution (`s8s8` and `wino_2x3`) and indicates that
+the weights are actually scaled (by `0.5`) due to a potential intermediate
+overflow when the result is accumulated to `int16_t`. While the Winograd
+implementation currently keeps this information in `wino_desc_t`, the
+`s8s8`-convolution and corresponding reorder knows it by always checking
+
+``` c++
+    scale_adjust = mayiuse(avx512) && !mayiuse(avx512_vnni) ? 1.f / 2.f : 1.f;
+```
+
+which seems inelegant. Moreover it probably makes sense to expose this value to
+the user.
+
+Finally, the field `reserved` is a precautionary measure for future extensions
+without breaking API / ABI.
+
+
+## 5. Other
+
+### 5.1 Reshape (?)
+
+This proposal should also make it possible to increase/decrease the number of
+dimensions in a tensor (instead of reshape?):
+
+``` c++
+// new_dims should be the same as dims, except for ones (there might be more
+// ones or less). Example: `{1, 3, 16, 1} --> {3, 1, 1, 16, 1, 1}`
+mkldnn_status_t mkldnn_memory_desc_change_dims(memory_desc_t *dst_md,
+        const memory_desc_t *src_md, int new_ndims, const dims_t new_dims);
+```


### PR DESCRIPTION
The Intel(R) MKL-DNN team is planning to release **v1.0** of the library in mid-2019. With this major version change, we would like to clean up the API to make Intel MKL-DNN easier to use. 

[This RFC](https://github.com/intel/mkl-dnn/tree/rfc-api-changes-v1.0/doc/rfc/api-v1.0) describes user-visible and some important internal changes to help developers understand what to expect in the future. The Intel MKL-DNN team would appreciate your feedback and suggestions on the given proposal! Feel free to post them in this PR.

**UPDATE 03/08/19**: [v1.0 Preview Candidate](https://github.com/intel/mkl-dnn/releases/tag/v1.0-pc) is released.
**UPDATE 03/12/19**: Update the RFC. See changes [here](https://github.com/intel/mkl-dnn/pull/384#issuecomment-472199131).