### PR TITLE
Add a build option MKLDNN_DISABLE_JIT OFF by default.

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -37,6 +37,11 @@ option(MKLDNN_ENABLE_CONCURRENT_EXEC
     CAUTION: enabling this option increases memory consumption"
     OFF) # disabled by default
 
+option(MKLDNN_DISABLE_JIT
+    "disables JIT at runtime by zeroing feartures in CPU and allows
+     cross compilation for the other platforms"
+    OFF) # disable by default
+
 # =============================
 # Building properties and scope
 # =============================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,11 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/cpu/xbyak
     )
 
+if(MKLDNN_DISABLE_JIT)
+    add_definitions(-DMKLDNN_DISABLE_JIT)
+    add_definitions(-DNON_X86_CPU)
+endif()
+
 # propagate SRC specific flags
 append(CMAKE_C_FLAGS "${CMAKE_SRC_CCXX_FLAGS}")
 append(CMAKE_CXX_FLAGS "${CMAKE_SRC_CCXX_FLAGS}")

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -19,7 +19,10 @@
 #include <malloc.h>
 #include <windows.h>
 #endif
+
+#ifndef MKLDNN_DISABLE_JIT
 #include "xmmintrin.h"
+#endif
 
 #include "utils.hpp"
 
@@ -84,6 +87,7 @@ FILE *mkldnn_fopen(const char *filename, const char *mode) {
 thread_local unsigned int mxcsr_save;
 
 void set_rnd_mode(round_mode_t rnd_mode) {
+#ifndef MKLDNN_DISABLE_JIT
     mxcsr_save = _mm_getcsr();
     unsigned int mxcsr = mxcsr_save & ~(3u << 13);
     switch (rnd_mode) {
@@ -92,10 +96,13 @@ void set_rnd_mode(round_mode_t rnd_mode) {
     default: assert(!"unreachable");
     }
     if (mxcsr != mxcsr_save) _mm_setcsr(mxcsr);
+#endif
 }
 
 void restore_rnd_mode() {
+#ifndef MKLDNN_DISABLE_JIT
     _mm_setcsr(mxcsr_save);
+#endif
 }
 
 void *malloc(size_t size, int alignment) {

--- a/tests/gtests/CMakeLists.txt
+++ b/tests/gtests/CMakeLists.txt
@@ -25,6 +25,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/common
                     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/cpu
                     )
+if(MKLDNN_DISABLE_JIT)
+    add_definitions(-DMKLDNN_DISABLE_JIT)
+    add_definitions(-DNON_X86_CPU)
+endif()
+
 if(WIN32)
     # Correct 'jnl' macro/jit issue
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")


### PR DESCRIPTION
If it is on, disable JIT in runtime by zeroing out features in CPU for
validating reference implementation and cross compilation mkl-dnn to
other platforms.

Signed-off-by: Yuan Juntao <juntao.yuan@intel.com>