### PR TITLE
fix compilation error on MINGW

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -51,7 +51,7 @@ static_assert(sizeof(void*) == 8, "Intel(R) MKL-DNN supports 64 bit only");
 
 #define IMPLICATION(cause, effect) (!(cause) || !!(effect))
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 


### PR DESCRIPTION
`__FUNCSIG__` is not defined on MINGW, but we can use `__PRETTY_FUNCTION__` instead.
