### PR TITLE
Better handling of full mkl / mklml check

### DIFF
--- a/cmake/MKL.cmake
+++ b/cmake/MKL.cmake
@@ -95,7 +95,8 @@ function(detect_mkl LIBNAME)
     if (MKLINC AND LIBNAME MATCHES "mklml")
         get_filename_component(__mklinc_root "${MKLINC}" PATH)
         find_library(tmp_MKLLIB NAMES "mkl_rt"
-            HINTS ${__mklinc_root}/lib/intel64)
+            HINTS ${__mklinc_root}/lib/intel64
+            NO_DEFAULT_PATH)
         set_if(tmp_MKLLIB MKLINC "")
         unset(tmp_MKLLIB CACHE)
     endif()


### PR DESCRIPTION
This change limits the searching for mkl_rt only in the lib path corresponding to the include path where `mkl_cblas.h` is found. This change makes the distinguish bewteen MKL and MKLML more reliable, when the system has both of them installed in different locations.