### PR TITLE
Add declarations of explicit specializations and instantiations.

### DIFF
--- a/src/cpu/cpu_reducer.hpp
+++ b/src/cpu/cpu_reducer.hpp
@@ -235,6 +235,10 @@ private:
             const memory_tracking::grantor_t &scratchpad) const;
 };
 
+// Explicit instantiations in cpu_reducer.cpp.
+extern template struct cpu_reducer_t<data_type::f32>;
+extern template struct cpu_reducer_t<data_type::s32>;
+
 template <impl::data_type_t data_type>
 struct cpu_reducer_2d_t {
     typedef typename prec_traits<data_type>::type data_t;
@@ -313,6 +317,10 @@ private:
             const memory_tracking::grantor_t &scratchpad) const;
 };
 
+// Explicit instantiations in cpu_reducer.cpp.
+extern template struct cpu_reducer_2d_t<data_type::f32>;
+extern template struct cpu_reducer_2d_t<data_type::s32>;
+
 /** simple 1d accumulator: y[:] += x[:] */
 template <impl::data_type_t data_type>
 struct cpu_accumulator_1d_t {
@@ -324,6 +332,10 @@ struct cpu_accumulator_1d_t {
 
     reducer_2d_driver_t<data_type> *drv_;
 };
+
+// Explicit instantiations in cpu_reducer.cpp.
+extern template struct cpu_accumulator_1d_t<data_type::f32>;
+extern template struct cpu_accumulator_1d_t<data_type::s32>;
 
 }
 }

--- a/src/cpu/gemm/f32/gemm_utils_f32.hpp
+++ b/src/cpu/gemm/f32/gemm_utils_f32.hpp
@@ -54,6 +54,17 @@ void sum_two_matrices(int m, int n,
         data_t * __restrict p_src, dim_t ld_src,
         data_t * __restrict p_dst, dim_t ld_dst);
 
+// Explicit instantiations in gemm_utils_f32.cpp.
+extern template
+void sum_two_matrices<float>(int m, int n,
+        float * __restrict p_src, dim_t ld_src,
+        float * __restrict p_dst, dim_t ld_dst);
+
+extern template
+void sum_two_matrices<double>(int m, int n,
+        double * __restrict p_src, dim_t ld_src,
+        double * __restrict p_dst, dim_t ld_dst);
+
 void calc_nthr_nocopy_avx512_common(int m,
         int n, int k, int nthrs, int *nthrs_m, int *nthrs_n, int *nthrs_k,
         int *BM, int *BN, int *BK);

--- a/src/cpu/gemm/f32/ref_gemm_f32.hpp
+++ b/src/cpu/gemm/f32/ref_gemm_f32.hpp
@@ -29,6 +29,16 @@ mkldnn_status_t ref_gemm(const char *transa, const char *transb, const int *M,
         const int *lda, const data_t *B, const int *ldb, const data_t *beta,
         data_t *C, const int *ldc, const data_t *bias);
 
+// Explicit instantiations in ref_gemm_f32.cpp.
+extern template mkldnn_status_t ref_gemm<float>(const char *transa, const char *transb, const int *M,
+        const int *N, const int *K, const float *alpha, const float *A,
+        const int *lda, const float *B, const int *ldb, const float *beta,
+        float *C, const int *ldc, const float *bias);
+extern template mkldnn_status_t ref_gemm<double>(const char *transa, const char *transb, const int *M,
+        const int *N, const int *K, const double *alpha, const double *A,
+        const int *lda, const double *B, const int *ldb, const double *beta,
+        double *C, const int *ldc, const double *bias);
+
 }
 }
 }

--- a/src/cpu/gemm/gemm.hpp
+++ b/src/cpu/gemm/gemm.hpp
@@ -37,6 +37,21 @@ mkldnn_status_t gemm_s8x8s32(const char *transa, const char *transb,
         const b_dt *B, const int *ldb, const int8_t *bo, const float *beta,
         int32_t *c, const int *ldc, const int32_t *co);
 
+// Explicit instantiations in gemm.cpp.
+extern template
+mkldnn_status_t gemm_s8x8s32(const char *transa, const char *transb,
+        const char *offsetc, const int *M, const int *N, const int *K,
+        const float *alpha, const int8_t *A, const int *LDA, const int8_t *ao,
+        const int8_t *B, const int *LDB, const int8_t *bo, const float *beta,
+        int32_t *C, const int *LDC, const int32_t *co);
+
+extern template
+mkldnn_status_t gemm_s8x8s32(const char *transa, const char *transb,
+        const char *offsetc, const int *M, const int *N, const int *K,
+        const float *alpha, const int8_t *A, const int *LDA, const int8_t *ao,
+        const uint8_t *B, const int *LDB, const int8_t *bo, const float *beta,
+        int32_t *C, const int *LDC, const int32_t *co);
+
 #ifdef USE_CBLAS
 #define GEMM_IMPL_STR "gemm:blas"
 #else

--- a/src/cpu/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8u8s32_kern.hpp
+++ b/src/cpu/gemm/s8x8s32/jit_avx512_core_kernel_gemv_s8u8s32_kern.hpp
@@ -59,6 +59,15 @@ public:
 
 };
 
+// Explicit instantiations in jit_avx512_core_kernel_gemv_s8u8s32_kern.cpp.
+extern template jit_avx512_core_gemv_s8u8s32_kern::gemv_s8u8s32_kernel_t
+jit_avx512_core_gemv_s8u8s32_kern::generate<
+    jit_avx512_core_gemv_s8u8s32_kern::gemv_s8u8s32_kernel_t>(int);
+
+extern template jit_avx512_core_gemv_s8u8s32_kern::gemv_u8s8s32_kernel_t
+jit_avx512_core_gemv_s8u8s32_kern::generate<
+    jit_avx512_core_gemv_s8u8s32_kern::gemv_u8s8s32_kernel_t>(int);
+
 }
 }
 }

--- a/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.hpp
+++ b/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.hpp
@@ -32,8 +32,22 @@ mkldnn_status_t ref_gemm_s8x8s32(const char *transa, const char *transb,
         const b_dt *B, const int *LDB, const int8_t *bo, const float *beta,
         int32_t *C, const int *LDC, const int32_t *co);
 
+// Explicit instantiations in ref_gemm_s8x8s32.cpp.
+extern template mkldnn_status_t ref_gemm_s8x8s32<uint8_t>(
+        const char *transa, const char *transb, const char *offsetc,
+        const int *M, const int *N, const int *K,
+        const float *alpha, const int8_t *A, const int *LDA, const int8_t *ao,
+        const uint8_t *B, const int *LDB, const int8_t *bo,
+        const float *beta, int32_t *C, const int *LDC, const int32_t *co);
+
+extern template mkldnn_status_t ref_gemm_s8x8s32<int8_t>(
+        const char *transa, const char *transb, const char *offsetc,
+        const int *M, const int *N, const int *K,
+        const float *alpha, const int8_t *A, const int *LDA, const int8_t *ao,
+        const int8_t *B, const int *LDB, const int8_t *bo,
+        const float *beta, int32_t *C, const int *LDC, const int32_t *co);
+
 }
 }
 }
 #endif
-

--- a/src/cpu/gemm_convolution_utils.hpp
+++ b/src/cpu/gemm_convolution_utils.hpp
@@ -40,6 +40,16 @@ void im2col_u8(const jit_gemm_conv_conf_t &jcp, const T *__restrict im,
         T* __restrict imtr, uint8_t *__restrict col,
         int hs, int hb, int ws, int wb);
 
+// Explicit instantiations in gemm_convolution_utils.cpp.
+extern template void im2col_u8<int8_t>(
+    const jit_gemm_conv_conf_t &jcp,
+    const int8_t *__restrict im, int8_t *__restrict imtr,
+    uint8_t *__restrict col, int hs, int hb, int ws, int wb);
+extern template void im2col_u8<uint8_t>(
+    const jit_gemm_conv_conf_t &jcp,
+    const uint8_t *__restrict im, uint8_t *__restrict imtr,
+    uint8_t *__restrict col, int hs, int hb, int ws, int wb);
+
 void col2im_s32(const jit_gemm_conv_conf_t &jcp, const int32_t *__restrict col,
         int32_t *__restrict im);
 void col2im_3d(const jit_gemm_conv_conf_t &jcp, const float *col, float *im,

--- a/src/cpu/gemm_inner_product.hpp
+++ b/src/cpu/gemm_inner_product.hpp
@@ -74,6 +74,9 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiation in gemm_inner_product.cpp.
+extern template struct gemm_inner_product_fwd_t<mkldnn::impl::data_type::f32>;
+
 template <impl::data_type_t data_type>
 struct gemm_inner_product_bwd_data_t: public cpu_primitive_t {
     struct pd_t: public cpu_inner_product_bwd_data_pd_t {
@@ -109,6 +112,9 @@ private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiation in gemm_inner_product.cpp.
+extern template struct gemm_inner_product_bwd_data_t<mkldnn::impl::data_type::f32>;
 
 template <impl::data_type_t data_type>
 struct gemm_inner_product_bwd_weights_t: public cpu_primitive_t {
@@ -148,6 +154,9 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiation in gemm_inner_product.cpp.
+extern template struct gemm_inner_product_bwd_weights_t<mkldnn::impl::data_type::f32>;
+
 }
 }
 }
@@ -155,4 +164,3 @@ private:
 #endif
 
 // vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s
-

--- a/src/cpu/gemm_x8s8s32x_convolution.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.hpp
@@ -190,6 +190,25 @@ private:
 
 };
 
+// Explicit instantiations in gemm_x8s8s32x_convolution.cpp.
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::f32>;
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::s32>;
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::s8>;
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::u8>;
+
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::f32>;
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::s32>;
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::s8>;
+extern template struct _gemm_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::u8>;
+
 template <data_type_t dst_type>
 struct _gemm_u8s8s32x_convolution_bwd_data_t: public cpu_primitive_t {
     struct pd_t: public cpu_convolution_bwd_data_pd_t{
@@ -258,6 +277,12 @@ private:
             const memory_tracking::grantor_t &scratchpad) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in gemm_x8s8s32x_convolution.cpp.
+extern template struct _gemm_u8s8s32x_convolution_bwd_data_t<data_type::f32>;
+extern template struct _gemm_u8s8s32x_convolution_bwd_data_t<data_type::s32>;
+extern template struct _gemm_u8s8s32x_convolution_bwd_data_t<data_type::s8>;
+extern template struct _gemm_u8s8s32x_convolution_bwd_data_t<data_type::u8>;
 
 }
 }

--- a/src/cpu/gemm_x8s8s32x_inner_product.hpp
+++ b/src/cpu/gemm_x8s8s32x_inner_product.hpp
@@ -157,6 +157,24 @@ private:
     pp_kernel_t *pp_kernel_;
 };
 
+// Explicit instantiations in gemm_x8s8s32x_inner_product.cpp.
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::u8, data_type::f32>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::u8, data_type::s32>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::u8, data_type::s8>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::u8, data_type::u8>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::s8, data_type::f32>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::s8, data_type::s32>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::s8, data_type::s8>;
+extern template struct gemm_x8s8s32x_inner_product_fwd_t<
+    data_type::s8, data_type::u8>;
+
 }
 }
 }

--- a/src/cpu/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/jit_avx512_common_1x1_convolution.hpp
@@ -131,6 +131,9 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public cpu_primitive_t {
     rtus_driver_t<avx512_common> *rtus_driver_;
 };
 
+// Explicit instantiations in jit_avx512_common_1x1_convolution.cpp.
+extern template struct jit_avx512_common_1x1_convolution_fwd_t<data_type::f32>;
+
 using jit_avx512_common_1x1_convolution_fwd_f32_t
         = jit_avx512_common_1x1_convolution_fwd_t<data_type::f32>;
 
@@ -227,6 +230,10 @@ struct jit_avx512_common_1x1_convolution_bwd_data_t : public cpu_primitive_t {
     jit_avx512_common_1x1_conv_kernel *kernel_;
     rtus_driver_t<avx512_common> *rtus_driver_;
 };
+
+// Explicit instantiations in jit_avx512_common_1x1_convolution.cpp.
+extern template struct jit_avx512_common_1x1_convolution_bwd_data_t<
+    data_type::f32>;
 
 using jit_avx512_common_1x1_convolution_bwd_data_f32_t
         = jit_avx512_common_1x1_convolution_bwd_data_t<data_type::f32>;

--- a/src/cpu/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/jit_avx512_common_conv_kernel.hpp
@@ -223,6 +223,17 @@ struct jit_avx512_common_conv_fwd_kernel {
     _jit_avx512_common_conv_fwd_kernel<Xbyak::Xmm> *xmm_kernel_;
 };
 
+// Explicit specializations and instantiations in
+// jit_avx512_common_conv_kernel.cpp.
+template<>
+void _jit_avx512_common_conv_fwd_kernel<Xbyak::Zmm>::compute_loop_4fma_1st(
+    int ur_w, int pad_l, int pad_r);
+template<>
+void _jit_avx512_common_conv_fwd_kernel<Xbyak::Zmm>::compute_loop_4fma(
+    int ur_w, int pad_l, int pad_r);
+extern template struct  _jit_avx512_common_conv_fwd_kernel<Xbyak::Zmm>;
+extern template struct  _jit_avx512_common_conv_fwd_kernel<Xbyak::Xmm>;
+
 struct jit_avx512_common_conv_bwd_data_kernel_f32: public jit_generator {
 
     jit_avx512_common_conv_bwd_data_kernel_f32(jit_conv_conf_t ajcp): jcp(ajcp)

--- a/src/cpu/jit_avx512_common_convolution.hpp
+++ b/src/cpu/jit_avx512_common_convolution.hpp
@@ -113,6 +113,9 @@ private:
     jit_avx512_common_conv_fwd_kernel *kernel_;
 };
 
+// Explicit instantiations in jit_avx512_common_convolution.cpp.
+extern template struct jit_avx512_common_convolution_fwd_t<data_type::f32>;
+
 template <impl::data_type_t diff_dst_type,
           impl::data_type_t wei_type = diff_dst_type,
           impl::data_type_t diff_src_type = diff_dst_type>
@@ -196,6 +199,9 @@ private:
 
     jit_avx512_common_conv_bwd_data_kernel_f32 *kernel_;
 };
+
+// Explicit instantiations in jit_avx512_common_convolution.cpp.
+extern template struct jit_avx512_common_convolution_bwd_data_t<data_type::f32>;
 
 template <impl::data_type_t src_type,
           impl::data_type_t diff_dst_type = src_type,
@@ -292,6 +298,10 @@ private:
     cpu_accumulator_1d_t<diff_weights_type> *acc_ker_;
     cpu_reducer_t<diff_weights_type> *reducer_bias_;
 };
+
+// Explicit instantiations in jit_avx512_common_convolution.cpp.
+extern template struct jit_avx512_common_convolution_bwd_weights_t<
+    data_type::f32>;
 
 }
 }

--- a/src/cpu/jit_avx512_common_convolution_winograd.hpp
+++ b/src/cpu/jit_avx512_common_convolution_winograd.hpp
@@ -80,6 +80,10 @@ struct _jit_avx512_common_convolution_winograd_t {
         const primitive_attr_t *attr_;
 };
 
+// Explicit instantiations in jit_avx512_common_convolution_winograd.cpp.
+extern template struct _jit_avx512_common_convolution_winograd_t<true>;
+extern template struct _jit_avx512_common_convolution_winograd_t<false>;
+
 struct jit_avx512_common_convolution_winograd_fwd_t
      : _jit_avx512_common_convolution_winograd_t<true>
      , public cpu_primitive_t

--- a/src/cpu/jit_avx512_core_fp32_wino_conv_4x3.hpp
+++ b/src/cpu/jit_avx512_core_fp32_wino_conv_4x3.hpp
@@ -112,6 +112,10 @@ struct _jit_avx512_core_fp32_wino_conv_4x3_t {
         const primitive_attr_t *attr_;
 };
 
+// Explicit instantiations in jit_avx512_core_fp32_wino_conv_4x3.cpp.
+extern template struct _jit_avx512_core_fp32_wino_conv_4x3_t<true>;
+extern template struct _jit_avx512_core_fp32_wino_conv_4x3_t<false>;
+
 struct jit_avx512_core_fp32_wino_conv_4x3_fwd_t
      : _jit_avx512_core_fp32_wino_conv_4x3_t<true>
      , public cpu_primitive_t

--- a/src/cpu/jit_avx512_core_u8s8s32x_wino_convolution.hpp
+++ b/src/cpu/jit_avx512_core_u8s8s32x_wino_convolution.hpp
@@ -119,6 +119,16 @@ private:
     jit_avx512_core_u8s8s32x_wino_conv_dst_trans_t *dst_trans_;
 };
 
+// Explicit instantiations in jit_avx512_core_u8s8s32x_wino_convolution.cpp.
+extern template struct jit_avx512_core_u8s8s32x_wino_convolution_fwd_t<
+    data_type::s8>;
+extern template struct jit_avx512_core_u8s8s32x_wino_convolution_fwd_t<
+    data_type::u8>;
+extern template struct jit_avx512_core_u8s8s32x_wino_convolution_fwd_t<
+    data_type::s32>;
+extern template struct jit_avx512_core_u8s8s32x_wino_convolution_fwd_t<
+    data_type::f32>;
+
 }
 }
 }

--- a/src/cpu/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -152,6 +152,24 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public cpu_primitive_t {
     rtus_driver_t<avx512_common> *rtus_driver_;
 };
 
+// Explicit instantiations in jit_avx512_core_x8s8s32x_1x1_convolution.cpp.
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::u8, data_type::u8>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::s8, data_type::u8>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::u8, data_type::s8>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::s8, data_type::s8>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::u8, data_type::s32>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::s8, data_type::s32>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::u8, data_type::f32>;
+extern template struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t<
+    data_type::s8, data_type::f32>;
+
 }
 }
 }

--- a/src/cpu/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -173,6 +173,19 @@ private:
     const Vmm vmm_mask(const Vmm vmm_in, bool mask_flag, bool store = false);
 };
 
+// Explicit specializations and instantiations in
+// jit_avx512_core_x8s8s32x_conv_kernel.cpp.
+template<>
+const Xbyak::Zmm _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Zmm>::
+    vmm_mask(const Xbyak::Zmm zmm_in, bool mask_flag, bool store);
+template <>
+void _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Zmm>::compute_ker_dw(
+    int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
+    bool h_padded);
+extern template struct  _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Zmm>;
+extern template struct  _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Ymm>;
+extern template struct  _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Xmm>;
+
 struct jit_avx512_core_x8s8s32x_fwd_kernel {
 
     jit_avx512_core_x8s8s32x_fwd_kernel(jit_conv_conf_t ajcp,

--- a/src/cpu/jit_avx512_core_x8s8s32x_convolution.hpp
+++ b/src/cpu/jit_avx512_core_x8s8s32x_convolution.hpp
@@ -106,6 +106,24 @@ private:
     jit_avx512_core_x8s8s32x_fwd_kernel *kernel_;
 };
 
+// Explicit instantiations in jit_avx512_core_x8s8s32x_convolution.cpp.
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::u8>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::u8>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::s8>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::s8>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::s32>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::s32>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::s8, data_type::f32>;
+extern template struct jit_avx512_core_x8s8s32x_convolution_fwd_t<
+    data_type::u8, data_type::f32>;
+
 }
 }
 }

--- a/src/cpu/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -228,6 +228,24 @@ private:
     jit_avx512_core_x8s8s32x_deconv_fwd_kernel *kernel_;
 };
 
+// Explicit instantiations in jit_avx512_core_x8s8s32x_deconvolution.cpp.
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::u8, data_type::u8>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::u8, data_type::s8>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::u8, data_type::f32>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::u8, data_type::s32>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::s8, data_type::u8>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::s8, data_type::s8>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::s8, data_type::f32>;
+extern template struct _jit_avx512_core_x8s8s32x_deconvolution_fwd_t<
+    data_type::s8, data_type::s32>;
+
 }
 }
 }

--- a/src/cpu/jit_uni_batch_normalization.hpp
+++ b/src/cpu/jit_uni_batch_normalization.hpp
@@ -62,6 +62,11 @@ private:
     uni_bnorm_driver_t<isa> *bnorm_driver_;
 };
 
+// Explicit instantiations in jit_uni_batch_normalization.cpp.
+extern template struct jit_uni_batch_normalization_fwd_t<sse42>;
+extern template struct jit_uni_batch_normalization_fwd_t<avx2>;
+extern template struct jit_uni_batch_normalization_fwd_t<avx512_common>;
+
 template <cpu_isa_t isa>
 struct jit_uni_batch_normalization_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_batch_normalization_bwd_pd_t {
@@ -90,6 +95,11 @@ private:
 
     uni_bnorm_driver_t<isa> *bnorm_driver_;
 };
+
+// Explicit instantiations in jit_uni_batch_normalization.cpp.
+extern template struct jit_uni_batch_normalization_bwd_t<sse42>;
+extern template struct jit_uni_batch_normalization_bwd_t<avx2>;
+extern template struct jit_uni_batch_normalization_bwd_t<avx512_common>;
 
 }
 }

--- a/src/cpu/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/jit_uni_dw_conv_kernel_f32.hpp
@@ -101,6 +101,11 @@ private:
     void generate();
 };
 
+// Explicit instantiations in jit_uni_dw_conv_kernel_f32.cpp.
+extern template struct jit_uni_dw_conv_fwd_kernel_f32<avx512_common>;
+extern template struct jit_uni_dw_conv_fwd_kernel_f32<avx2>;
+extern template struct jit_uni_dw_conv_fwd_kernel_f32<sse42>;
+
 template <cpu_isa_t isa>
 struct jit_uni_dw_conv_bwd_data_kernel_f32: public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32)
@@ -154,6 +159,11 @@ private:
 
     void generate();
 };
+
+// Explicit instantiations in jit_uni_dw_conv_kernel_f32.cpp.
+extern template struct jit_uni_dw_conv_bwd_data_kernel_f32<avx512_common>;
+extern template struct jit_uni_dw_conv_bwd_data_kernel_f32<avx2>;
+extern template struct jit_uni_dw_conv_bwd_data_kernel_f32<sse42>;
 
 template <cpu_isa_t isa>
 struct jit_uni_dw_conv_bwd_weights_kernel_f32 : public jit_generator {
@@ -246,6 +256,12 @@ private:
 
     void generate();
 };
+
+// Explicit instantiations in jit_uni_dw_conv_kernel_f32.cpp.
+extern template struct jit_uni_dw_conv_bwd_weights_kernel_f32<avx512_common>;
+extern template struct jit_uni_dw_conv_bwd_weights_kernel_f32<avx2>;
+extern template struct jit_uni_dw_conv_bwd_weights_kernel_f32<sse42>;
+
 }
 }
 }

--- a/src/cpu/jit_uni_dw_convolution.hpp
+++ b/src/cpu/jit_uni_dw_convolution.hpp
@@ -97,6 +97,11 @@ private:
     jit_uni_dw_conv_fwd_kernel_f32<isa> *kernel_;
 };
 
+// Explicit instantiations in jit_uni_dw_convolution.cpp.
+extern template struct _jit_uni_dw_convolution_fwd_t<avx512_common>;
+extern template struct _jit_uni_dw_convolution_fwd_t<avx2>;
+extern template struct _jit_uni_dw_convolution_fwd_t<sse42>;
+
 using jit_avx512_common_dw_convolution_fwd_t =
     _jit_uni_dw_convolution_fwd_t<avx512_common>;
 using jit_avx2_dw_convolution_fwd_t = _jit_uni_dw_convolution_fwd_t<avx2>;
@@ -170,6 +175,11 @@ private:
 
     jit_uni_dw_conv_bwd_data_kernel_f32<isa> *kernel_;
 };
+
+// Explicit instantiations in jit_uni_dw_convolution.cpp.
+extern template struct _jit_uni_dw_convolution_bwd_data_t<avx512_common>;
+extern template struct _jit_uni_dw_convolution_bwd_data_t<avx2>;
+extern template struct _jit_uni_dw_convolution_bwd_data_t<sse42>;
 
 using jit_avx512_common_dw_convolution_bwd_data_t =
     _jit_uni_dw_convolution_bwd_data_t<avx512_common>;
@@ -251,6 +261,11 @@ private:
     jit_uni_dw_conv_bwd_weights_kernel_f32<isa> *kernel_;
     cpu_accumulator_1d_t<data_type::f32> *acc_ker_;
 };
+
+// Explicit instantiations in jit_uni_dw_convolution.cpp.
+extern template struct _jit_uni_dw_convolution_bwd_weights_t<avx512_common>;
+extern template struct _jit_uni_dw_convolution_bwd_weights_t<avx2>;
+extern template struct _jit_uni_dw_convolution_bwd_weights_t<sse42>;
 
 using jit_avx512_common_dw_convolution_bwd_weights_t =
     _jit_uni_dw_convolution_bwd_weights_t<avx512_common>;

--- a/src/cpu/jit_uni_eltwise.hpp
+++ b/src/cpu/jit_uni_eltwise.hpp
@@ -128,6 +128,11 @@ private:
     void bounded_relu_prepare_table();
 };
 
+// Explicit instantiations in jit_uni_eltwise.cpp.
+extern template struct jit_uni_eltwise_injector_f32<avx512_common>;
+extern template struct jit_uni_eltwise_injector_f32<avx2>;
+extern template struct jit_uni_eltwise_injector_f32<sse42>;
+
 struct jit_uni_eltwise_kernel_f32;
 
 template <cpu_isa_t isa>
@@ -158,6 +163,11 @@ private:
     jit_uni_eltwise_kernel_f32 *kernel_;
 };
 
+// Explicit instantiations in jit_uni_eltwise.cpp.
+extern template struct jit_uni_eltwise_fwd_t<sse42>;
+extern template struct jit_uni_eltwise_fwd_t<avx2>;
+extern template struct jit_uni_eltwise_fwd_t<avx512_common>;
+
 template <cpu_isa_t isa>
 struct jit_uni_eltwise_bwd_t : public cpu_primitive_t {
     struct pd_t : public cpu_eltwise_bwd_pd_t {
@@ -185,6 +195,11 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
     jit_uni_eltwise_kernel_f32 *kernel_;
 };
+
+// Explicit instantiations in jit_uni_eltwise.cpp.
+extern template struct jit_uni_eltwise_bwd_t<sse42>;
+extern template struct jit_uni_eltwise_bwd_t<avx2>;
+extern template struct jit_uni_eltwise_bwd_t<avx512_common>;
 
 }
 }

--- a/src/cpu/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/jit_uni_i8i8_pooling.hpp
@@ -82,6 +82,10 @@ private:
     jit_uni_i8i8_pooling_fwd_ker_t<isa> *ker_;
 };
 
+// Explicit instantiations in jit_uni_i8i8_pooling.cpp.
+extern template struct jit_uni_i8i8_pooling_fwd_t<avx512_core>;
+extern template struct jit_uni_i8i8_pooling_fwd_t<avx2>;
+
 }
 }
 }

--- a/src/cpu/jit_uni_lrn.hpp
+++ b/src/cpu/jit_uni_lrn.hpp
@@ -63,6 +63,10 @@ private:
     jit_uni_lrn_fwd_kernel_f32<isa> *ker_, *ker_first_, *ker_last_;
 };
 
+// Explicit instantiations in jit_uni_lrn.cpp.
+extern template struct jit_uni_lrn_fwd_t<sse42>;
+extern template struct jit_uni_lrn_fwd_t<avx2>;
+
 template <cpu_isa_t isa>
 struct jit_uni_lrn_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_lrn_bwd_pd_t {
@@ -93,6 +97,9 @@ private:
 
     jit_uni_lrn_bwd_kernel_f32<isa> *ker_, *ker_first_, *ker_last_;
 };
+
+// Explicit instantiations in jit_uni_lrn.cpp.
+extern template struct jit_uni_lrn_bwd_t<avx2>;
 
 }
 }

--- a/src/cpu/jit_uni_lrn_kernel_f32.hpp
+++ b/src/cpu/jit_uni_lrn_kernel_f32.hpp
@@ -145,6 +145,58 @@ struct jit_uni_lrn_fwd_kernel_f32 : public jit_generator {
     void(*ker)(jit_args_fwd_t *);
 };
 
+// Explicit specializations and instantiations in jit_uni_lrn_fwd_kernel_f32.cpp.
+template<>
+jit_uni_lrn_fwd_kernel_f32<avx2>::jit_uni_lrn_fwd_kernel_f32(
+    const struct nchw8c_across &J, float A, float K, prop_kind_t pk,
+    void *code_ptr, size_t code_size);
+template<>
+jit_uni_lrn_fwd_kernel_f32<sse42>::jit_uni_lrn_fwd_kernel_f32(
+    const struct nchw8c_across &J, float A, float K, prop_kind_t pk,
+    void *code_ptr, size_t code_size);
+template<>
+jit_uni_lrn_fwd_kernel_f32<avx2>::jit_uni_lrn_fwd_kernel_f32(
+    const struct nhwc_across &J, float A, float K, prop_kind_t pk,
+    void *code_ptr, size_t code_size);
+template<>
+jit_uni_lrn_fwd_kernel_f32<sse42>::jit_uni_lrn_fwd_kernel_f32(
+    const struct nhwc_across &J, float A, float K, prop_kind_t pk,
+    void *code_ptr, size_t code_size);
+template<>
+void jit_uni_lrn_fwd_kernel_f32<sse42>::nchw_body(
+    int tail, int HW, prop_kind_t pk, Xbyak::Ymm ymask, Xbyak::Ymm ya,
+    Xbyak::Ymm yb, Xbyak::Ymm yc, Xbyak::Ymm yd, Xbyak::Ymm ye,
+    Xbyak::Ymm ysum);
+template<>
+void jit_uni_lrn_fwd_kernel_f32<avx2>::nchw_body(
+    int tail, int HW, prop_kind_t pk, Xbyak::Ymm ymask, Xbyak::Ymm ya,
+    Xbyak::Ymm yb, Xbyak::Ymm yc, Xbyak::Ymm yd, Xbyak::Ymm ye,
+    Xbyak::Ymm ysum);
+template<>
+void jit_uni_lrn_fwd_kernel_f32<avx2>::nchw_tail_sse42(
+    int tail, Xbyak::Reg64 reg_dst, Xbyak::Xmm xtail_lo, Xbyak::Xmm xtail_hi);
+template<>
+void jit_uni_lrn_fwd_kernel_f32<sse42>::nchw_tail_sse42(
+    int tail, Xbyak::Reg64 reg_dst, Xbyak::Xmm xtail_lo, Xbyak::Xmm xtail_hi);
+template<>
+void jit_uni_lrn_fwd_kernel_f32<sse42>::nchw_body_sse42(
+    int tail, int HW, prop_kind_t pk, Xbyak::Xmm xmask_lo, Xbyak::Xmm xmask_hi,
+    Xbyak::Xmm xe_lo, Xbyak::Xmm xe_hi, Xbyak::Xmm xsum_lo, Xbyak::Xmm xsum_hi);
+template<>
+void jit_uni_lrn_fwd_kernel_f32<avx2>::nchw_body_sse42(
+    int tail, int HW, prop_kind_t pk, Xbyak::Xmm xmask_lo, Xbyak::Xmm xmask_hi,
+    Xbyak::Xmm xe_lo, Xbyak::Xmm xe_hi, Xbyak::Xmm xsum_lo, Xbyak::Xmm xsum_hi);
+template<>
+jit_uni_lrn_fwd_kernel_f32<avx2>::jit_uni_lrn_fwd_kernel_f32(
+    struct nchw_across J, float A, float K, prop_kind_t pk, void* code_ptr,
+    size_t code_size);
+template<>
+jit_uni_lrn_fwd_kernel_f32<sse42>::jit_uni_lrn_fwd_kernel_f32(
+    struct nchw_across J, float A, float K, prop_kind_t pk, void* code_ptr,
+    size_t code_size);
+extern template struct jit_uni_lrn_fwd_kernel_f32<sse42>;
+extern template struct jit_uni_lrn_fwd_kernel_f32<avx2>;
+
 template <cpu_isa_t isa>
 struct jit_uni_lrn_bwd_kernel_f32 : public jit_generator {
     Xbyak::Reg64 src = rax;
@@ -173,6 +225,9 @@ struct jit_uni_lrn_bwd_kernel_f32 : public jit_generator {
     void operator()(jit_args_bwd_t *arg) { ker(arg); }
     void(*ker)(jit_args_bwd_t *);
 };
+
+// Explicit instantiation in jit_uni_lrn_kernel_f32.cpp.
+extern template struct jit_uni_lrn_bwd_kernel_f32<avx2>;
 
 }
 }

--- a/src/cpu/jit_uni_pool_kernel_f32.hpp
+++ b/src/cpu/jit_uni_pool_kernel_f32.hpp
@@ -183,6 +183,11 @@ private:
     }
 };
 
+// Explicit instantiations in jit_uni_pool_kernel_f32.cpp.
+extern template struct jit_uni_pool_kernel_f32<sse42>;
+extern template struct jit_uni_pool_kernel_f32<avx>;
+extern template struct jit_uni_pool_kernel_f32<avx512_common>;
+
 }
 }
 }

--- a/src/cpu/jit_uni_pooling.hpp
+++ b/src/cpu/jit_uni_pooling.hpp
@@ -101,6 +101,11 @@ private:
     jit_uni_pool_kernel_f32<isa> *kernel_;
 };
 
+// Explicit instantiations in jit_uni_pooling.cpp.
+extern template struct jit_uni_pooling_fwd_t<sse42>;
+extern template struct jit_uni_pooling_fwd_t<avx>;
+extern template struct jit_uni_pooling_fwd_t<avx512_common>;
+
 template <cpu_isa_t isa>
 struct jit_uni_pooling_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_pooling_bwd_pd_t {
@@ -172,6 +177,11 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
     jit_uni_pool_kernel_f32<isa> *kernel_;
 };
+
+// Explicit instantiations in jit_uni_pooling.cpp.
+extern template struct jit_uni_pooling_bwd_t<sse42>;
+extern template struct jit_uni_pooling_bwd_t<avx>;
+extern template struct jit_uni_pooling_bwd_t<avx512_common>;
 
 }
 }

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -76,6 +76,9 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in nchw_pooling.cpp.
+extern template struct nchw_pooling_fwd_t<data_type::f32>;
+
 template <impl::data_type_t data_type>
 struct nchw_pooling_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_pooling_bwd_pd_t {
@@ -137,6 +140,9 @@ private:
     void execute_backward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in nchw_pooling.cpp.
+extern template struct nchw_pooling_bwd_t<data_type::f32>;
 
 }
 }

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -153,6 +153,9 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in nhwc_pooling.cpp.
+extern template struct nhwc_pooling_fwd_t<data_type::f32>;
+
 template <impl::data_type_t data_type>
 struct nhwc_pooling_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_pooling_bwd_pd_t {
@@ -200,6 +203,9 @@ private:
     void execute_backward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in nhwc_pooling.cpp.
+extern template struct nhwc_pooling_bwd_t<data_type::f32>;
 
 }// namespace cpu
 }// namespace impl

--- a/src/cpu/ref_batch_normalization.hpp
+++ b/src/cpu/ref_batch_normalization.hpp
@@ -73,6 +73,9 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_batch_normalization.cpp.
+extern template struct ref_batch_normalization_fwd_t<data_type::f32>;
+
 template <impl::data_type_t data_type>
 struct ref_batch_normalization_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_batch_normalization_bwd_pd_t {
@@ -117,6 +120,9 @@ private:
     void execute_backward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in ref_batch_normalization.cpp.
+extern template struct ref_batch_normalization_bwd_t<data_type::f32>;
 
 }
 }

--- a/src/cpu/ref_convolution.hpp
+++ b/src/cpu/ref_convolution.hpp
@@ -86,6 +86,19 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_convolution.cpp.
+extern template struct ref_convolution_fwd_t<data_type::f32>;
+
+extern template struct ref_convolution_fwd_t<data_type::u8, data_type::s8,
+    data_type::f32, data_type::s32>;
+extern template struct ref_convolution_fwd_t<data_type::u8, data_type::s8,
+    data_type::s32, data_type::s32>;
+extern template struct ref_convolution_fwd_t<data_type::u8, data_type::s8,
+    data_type::s8, data_type::s32>;
+extern template struct ref_convolution_fwd_t<data_type::u8, data_type::s8,
+    data_type::u8, data_type::s32>;
+
+
 template <impl::data_type_t diff_src_type, impl::data_type_t wei_type,
          impl::data_type_t diff_dst_type,
          impl::data_type_t acc_type = diff_src_type>
@@ -137,6 +150,19 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_convolution.cpp.
+extern template struct ref_convolution_bwd_data_t<data_type::f32,
+    data_type::f32, data_type::f32, data_type::f32>;
+
+extern template struct ref_convolution_bwd_data_t<data_type::f32, data_type::s8,
+    data_type::u8, data_type::s32>;
+extern template struct ref_convolution_bwd_data_t<data_type::s32, data_type::s8,
+    data_type::u8, data_type::s32>;
+extern template struct ref_convolution_bwd_data_t<data_type::s8, data_type::s8,
+    data_type::u8, data_type::s32>;
+extern template struct ref_convolution_bwd_data_t<data_type::u8, data_type::s8,
+    data_type::u8, data_type::s32>;
+
 template <impl::data_type_t src_type, impl::data_type_t diff_wei_type,
          impl::data_type_t diff_dst_type,
          impl::data_type_t acc_type = diff_wei_type>
@@ -184,6 +210,10 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in ref_convolution.cpp.
+extern template struct ref_convolution_bwd_weights_t<data_type::f32,
+    data_type::f32, data_type::f32, data_type::f32>;
 
 }
 }

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -257,6 +257,14 @@ private:
     primitive_t *conv_p_;
 };
 
+// Explicit instantiations in ref_deconvolution.cpp.
+extern template void
+ref_deconvolution_fwd_t::compute_fwd_bias_nCdhwXc<8>(
+    const data_t *diff_dst, data_t *diff_bias) const;
+extern template void
+ref_deconvolution_fwd_t::compute_fwd_bias_nCdhwXc<16>(
+    const data_t *diff_dst, data_t *diff_bias) const;
+
 struct ref_deconvolution_bwd_data_t: public cpu_primitive_t {
     struct pd_t: public cpu_deconvolution_bwd_data_pd_t {
         pd_t(engine_t *engine, const deconvolution_desc_t *adesc,
@@ -492,6 +500,14 @@ private:
 
     primitive_t *conv_p_;
 };
+
+// Explicit instantiations in ref_deconvolution.cpp.
+extern template void
+ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc<8>(
+    const data_t *diff_dst, data_t *diff_bias) const;
+extern template void
+ref_deconvolution_bwd_weights_t::compute_bwd_bias_nCdhwXc<16>(
+    const data_t *diff_dst, data_t *diff_bias) const;
 
 }
 }

--- a/src/cpu/ref_eltwise.hpp
+++ b/src/cpu/ref_eltwise.hpp
@@ -105,6 +105,12 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_eltwise.cpp.
+extern template struct ref_eltwise_fwd_t<data_type::f32>;
+extern template struct ref_eltwise_fwd_t<data_type::s32>;
+extern template struct ref_eltwise_fwd_t<data_type::s8>;
+extern template struct ref_eltwise_fwd_t<data_type::u8>;
+
 template <impl::data_type_t data_type>
 struct ref_eltwise_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_eltwise_bwd_pd_t {
@@ -158,6 +164,10 @@ private:
     void execute_backward_generic(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in ref_eltwise.cpp.
+extern template struct ref_eltwise_bwd_t<data_type::f32>;
+extern template struct ref_eltwise_bwd_t<data_type::s32>;
 
 }
 }

--- a/src/cpu/ref_inner_product.hpp
+++ b/src/cpu/ref_inner_product.hpp
@@ -76,6 +76,17 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_inner_product.cpp.
+extern template struct ref_inner_product_fwd_t<data_type::f32>;
+extern template struct ref_inner_product_fwd_t<data_type::u8, data_type::s8,
+    data_type::f32, data_type::s32>;
+extern template struct ref_inner_product_fwd_t<data_type::u8, data_type::s8,
+    data_type::s32, data_type::s32>;
+extern template struct ref_inner_product_fwd_t<data_type::u8, data_type::s8,
+    data_type::s8, data_type::s32>;
+extern template struct ref_inner_product_fwd_t<data_type::u8, data_type::s8,
+    data_type::u8, data_type::s32>;
+
 template <impl::data_type_t diff_src_type, impl::data_type_t wei_type,
          impl::data_type_t diff_dst_type,
          impl::data_type_t acc_type = diff_src_type>
@@ -115,6 +126,10 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_inner_product.cpp.
+extern template struct ref_inner_product_bwd_data_t<data_type::f32,
+    data_type::f32, data_type::f32, data_type::f32>;
+
 template <impl::data_type_t data_type>
 struct ref_inner_product_bwd_weights_t: public cpu_primitive_t {
     struct pd_t: public cpu_inner_product_bwd_weights_pd_t {
@@ -149,6 +164,9 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in ref_inner_product.cpp.
+extern template struct ref_inner_product_bwd_weights_t<data_type::f32>;
 
 }
 }

--- a/src/cpu/ref_lrn.hpp
+++ b/src/cpu/ref_lrn.hpp
@@ -76,6 +76,23 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_lrn.cpp.
+extern template void
+ref_lrn_fwd_t<data_type::f32>::execute_forward<format_tag::nChw16c>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_fwd_t<data_type::f32>::execute_forward<format_tag::nChw8c>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_fwd_t<data_type::f32>::execute_forward<format_tag::nchw>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_fwd_t<data_type::f32>::execute_forward<format_tag::nhwc>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_fwd_t<data_type::f32>::execute_forward<format_tag::any>(
+    const exec_ctx_t &ctx) const;
+
 template <impl::data_type_t data_type>
 struct ref_lrn_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_lrn_bwd_pd_t {
@@ -126,6 +143,23 @@ private:
     void execute_backward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in ref_lrn.cpp.
+extern template void
+ref_lrn_bwd_t<data_type::f32>::execute_backward<format_tag::nChw16c>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_bwd_t<data_type::f32>::execute_backward<format_tag::nChw8c>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_bwd_t<data_type::f32>::execute_backward<format_tag::nchw>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_bwd_t<data_type::f32>::execute_backward<format_tag::nhwc>(
+    const exec_ctx_t &ctx) const;
+extern template void
+ref_lrn_bwd_t<data_type::f32>::execute_backward<format_tag::any>(
+    const exec_ctx_t &ctx) const;
 
 }
 }

--- a/src/cpu/ref_pooling.hpp
+++ b/src/cpu/ref_pooling.hpp
@@ -70,6 +70,12 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in ref_pooling.cpp.
+extern template struct ref_pooling_fwd_t<data_type::f32>;
+extern template struct ref_pooling_fwd_t<data_type::s32>;
+extern template struct ref_pooling_fwd_t<data_type::s8, data_type::s32>;
+extern template struct ref_pooling_fwd_t<data_type::u8, data_type::s32>;
+
 template <impl::data_type_t data_type, impl::data_type_t acc_type = data_type>
 struct ref_pooling_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_pooling_bwd_pd_t {
@@ -109,6 +115,10 @@ private:
     void execute_backward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
+
+// Explicit instantiations in ref_pooling.cpp.
+extern template struct ref_pooling_bwd_t<data_type::f32>;
+extern template struct ref_pooling_bwd_t<data_type::s32>;
 
 }
 }

--- a/src/cpu/ref_shuffle.hpp
+++ b/src/cpu/ref_shuffle.hpp
@@ -102,6 +102,45 @@ private:
     int *rev_transposed_;
 };
 
+// Explicit instantiations in ref_shuffle.cpp.
+extern template void
+ref_shuffle_t<4>::execute_<format_tag::nCdhw16c>(const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::nChw16c>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::nCdhw8c>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::nChw8c>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::ncdhw>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::nchw>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::ndhwc>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::nhwc>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<4>::execute_<format_tag::any>(
+    const exec_ctx_t &ctx) const;
+
+extern template void
+ref_shuffle_t<1>::execute_<format_tag::nCdhw16c>(const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::nChw16c>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::nCdhw8c>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::nChw8c>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::ncdhw>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::nchw>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::ndhwc>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::nhwc>(
+    const exec_ctx_t &ctx) const;
+extern template void ref_shuffle_t<1>::execute_<format_tag::any>(
+    const exec_ctx_t &ctx) const;
+
 }
 }
 }

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -112,6 +112,9 @@ private:
     int outer_size_, channels_, inner_size_;
 };
 
+// Explicit instantiations in ref_softmax.cpp.
+extern template struct ref_softmax_fwd_t<data_type::f32>;
+
 template <impl::data_type_t data_type>
 struct ref_softmax_bwd_t: public cpu_primitive_t {
     struct pd_t: public cpu_softmax_bwd_pd_t {
@@ -176,6 +179,8 @@ private:
     int outer_size_, channels_, inner_size_;
 };
 
+// Explicit instantiations in ref_softmax.cpp.
+extern template struct ref_softmax_bwd_t<data_type::f32>;
 
 }
 }

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -758,26 +758,6 @@ void _ref_rnn_common_t<aprop, src_type, weights_type>::execute_(
         assert(!"unimplemented");
 };
 
-/* Fix for MSVS warning C4661 */
-template<> rnn_cell_execution_sig(ref_rnn_fwd_f32_t::cell_execution);
-template<> rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution);
-template<> rnn_cell_execution_sig(ref_rnn_bwd_f32_t::cell_execution);
-template<> rnn_cell_execution_sig(ref_rnn_fwd_f32_t::cell_execution_gru);
-template<> rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution_gru);
-template<> rnn_cell_execution_sig(ref_rnn_bwd_f32_t::cell_execution_gru);
-template<> rnn_cell_execution_sig(ref_rnn_fwd_f32_t::cell_execution_gru_lbr);
-template<> rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution_gru_lbr);
-template<> rnn_cell_execution_sig(ref_rnn_bwd_f32_t::cell_execution_gru_lbr);
-template<> rnn_elemwise_sig(ref_rnn_fwd_f32_t::rnn_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_fwd_u8s8_t::rnn_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_bwd_f32_t::rnn_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_fwd_f32_t::lstm_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_fwd_u8s8_t::lstm_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_bwd_f32_t::lstm_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_fwd_f32_t::gru_lbr_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_fwd_u8s8_t::gru_lbr_elemwise);
-template<> rnn_elemwise_sig(ref_rnn_bwd_f32_t::gru_lbr_elemwise);
-
 template struct _ref_rnn_common_t<prop_kind::forward, data_type::f32, data_type::f32>;
 template struct _ref_rnn_common_t<prop_kind::forward, data_type::u8, data_type::s8>;
 template struct _ref_rnn_common_t<prop_kind::backward, data_type::f32, data_type::f32>;

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -320,6 +320,102 @@ private:
 using ref_rnn_fwd_f32_t = _ref_rnn_common_t<prop_kind::forward, data_type::f32, data_type::f32>;
 using ref_rnn_bwd_f32_t = _ref_rnn_common_t<prop_kind::backward, data_type::f32, data_type::f32>;
 using ref_rnn_fwd_u8s8_t = _ref_rnn_common_t<prop_kind::forward, data_type::u8, data_type::s8>;
+
+// Explicit specializations and instantiations in cell_common.cpp.
+template <>
+rnn_cell_execution_sig((ref_rnn_bwd_f32_t::cell_execution));
+extern template rnn_cell_execution_sig(ref_rnn_fwd_f32_t::cell_execution);
+extern template rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution);
+
+// Explicit specializations in cell_gru.cpp.
+template <>
+rnn_cell_execution_sig(ref_rnn_fwd_f32_t::cell_execution_gru);
+template <>
+rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution_gru);
+template <>
+rnn_cell_execution_sig(ref_rnn_bwd_f32_t::cell_execution_gru);
+
+// Explicit specializations in cell_gru_lbr.cpp.
+template <>
+rnn_elemwise_sig(ref_rnn_fwd_f32_t::gru_lbr_elemwise);
+template <>
+rnn_elemwise_sig(ref_rnn_fwd_u8s8_t::gru_lbr_elemwise);
+template <>
+rnn_cell_execution_sig(ref_rnn_fwd_f32_t::cell_execution_gru_lbr);
+template <>
+rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution_gru_lbr);
+template <>
+rnn_elemwise_sig(ref_rnn_bwd_f32_t::gru_lbr_elemwise);
+template <>
+rnn_cell_execution_sig(ref_rnn_bwd_f32_t::cell_execution_gru_lbr);
+
+// Explicit specializations in cell_lstm.cpp.
+template <>
+rnn_elemwise_sig(ref_rnn_fwd_f32_t::lstm_elemwise);
+template <>
+rnn_elemwise_sig(ref_rnn_fwd_u8s8_t::lstm_elemwise);
+template <>
+rnn_elemwise_sig(ref_rnn_bwd_f32_t::lstm_elemwise);
+
+// Explicit specializations in cell_rnn.cpp.
+template <>
+float activation<alg_kind::eltwise_relu, prop_kind::forward>(
+    float dd, float s, float alpha, float cliping);
+template <>
+float activation<alg_kind::eltwise_relu, prop_kind::backward>(
+    float dd, float s, float alpha, float cliping);
+template <>
+float activation<alg_kind::eltwise_tanh, prop_kind::forward>(
+    float dd, float s, float alpha, float cliping);
+template <>
+float activation<alg_kind::eltwise_tanh, prop_kind::backward>(
+    float dd, float s, float alpha, float cliping);
+template <>
+float activation<alg_kind::eltwise_logistic, prop_kind::forward>(
+    float dd, float s, float alpha, float cliping);
+template <>
+float activation<alg_kind::eltwise_logistic, prop_kind::backward>(
+    float dd, float s, float alpha, float cliping);
+template <>
+rnn_elemwise_sig(ref_rnn_fwd_f32_t::rnn_elemwise);
+template <>
+rnn_elemwise_sig(ref_rnn_fwd_u8s8_t::rnn_elemwise);
+template <>
+rnn_elemwise_sig(ref_rnn_bwd_f32_t::rnn_elemwise);
+
+// Explicit specializations and instantiations in ref_rnn.cpp.
+template <>
+rnn_gemm_sig((ref_rnn_fwd_u8s8_t::gemm));
+template <>
+rnn_gemm_sig((ref_rnn_fwd_u8s8_t::packed_gemm));
+template <>
+void ref_rnn_bwd_f32_t::copy_init_layer(
+    const rnn_utils::rnn_conf_t &rnn,
+    src_data_t *ws_states_, float *ws_diff_states_, const src_data_t *xt_,
+    const float *diff_dst_layer_) const;
+template <>
+template <typename input_data_t>
+void ref_rnn_bwd_f32_t::copy_init_iter(
+    const rnn_utils::rnn_conf_t &rnn,
+    src_data_t *ws_states_, float *ws_c_states_, float *ws_diff_states_,
+    const input_data_t *firstit_states_,
+    const float *diff_dst_iter_) const;
+template <>
+template <typename dst_data_t>
+void ref_rnn_bwd_f32_t::copy_res_layer(
+    const rnn_utils::rnn_conf_t &rnn, dst_data_t *dst_layer_, float *diff_src_layer_,
+    const src_data_t *ws_states_, const float *ws_diff_states_) const;
+template <>
+template <typename output_data_t>
+void ref_rnn_bwd_f32_t::copy_res_iter(
+    const rnn_utils::rnn_conf_t &rnn, output_data_t *dst_iter_, float *diff_src_iter_,
+    const src_data_t *ws_states_, float *ws_c_states_,
+    const float *ws_diff_states_) const;
+
+extern template struct _ref_rnn_common_t<prop_kind::forward, data_type::f32, data_type::f32>;
+extern template struct _ref_rnn_common_t<prop_kind::forward, data_type::u8, data_type::s8>;
+extern template struct _ref_rnn_common_t<prop_kind::backward, data_type::f32, data_type::f32>;
+
 }
 }
 }

--- a/src/cpu/simple_concat.hpp
+++ b/src/cpu/simple_concat.hpp
@@ -148,6 +148,12 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in simple_concat.cpp.
+extern template struct simple_concat_t<data_type::f32>;
+extern template struct simple_concat_t<data_type::u8>;
+extern template struct simple_concat_t<data_type::s8>;
+extern template struct simple_concat_t<data_type::s32>;
+
 }
 }
 }

--- a/src/cpu/simple_sum.hpp
+++ b/src/cpu/simple_sum.hpp
@@ -65,6 +65,9 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
 };
 
+// Explicit instantiations in simple_sum.cpp.
+extern template struct simple_sum_t<data_type::f32>;
+
 }
 }
 }


### PR DESCRIPTION
Currently, code that uses the specializations in question will
accidentally and erroneously specialize the primary template. The
reason this appears to "work" is a pure accident due to the way the
linker currently works. The code violates the one-definition-rule,
and all programs depending on it are ill-formed, no diagnostic
required (i.e. running all such programs has undefined behaviour).

Additionally, declaring explicit instantiations is also good
practice, since it declares intent and prevents accidental later
explicit specializations (it would be an error to declare those
after the extern declaration of the explicit instantiation had been
seen).

Explicit specializations and instantiations are declared in .hpp
files near the respective template.

(Found by @tkoeppe by compiling with clang -Wundefined-func-template.)