### PR TITLE
vcmpps is unnecessary

### DIFF
--- a/src/cpu/jit_generator.hpp
+++ b/src/cpu/jit_generator.hpp
@@ -670,6 +670,10 @@ public:
                       const int imm) {
         vroundps(x, op, imm);
     }
+    void uni_vroundps(const Xbyak::Zmm &x, const Xbyak::Operand &op,
+                      const int imm) {
+        vrndscaleps(x, op, imm & 0x3);
+    }
 
     void uni_vcvtps2dq(const Xbyak::Xmm &x, const Xbyak::Operand &op) {
         cvtps2dq(x, op);

--- a/src/cpu/jit_uni_eltwise.cpp
+++ b/src/cpu/jit_uni_eltwise.cpp
@@ -423,11 +423,6 @@ void jit_uni_eltwise_injector_f32<isa>::soft_relu_compute_vector(
     if (isa == avx512_common) {
         h->vcvtps2dq(vmm_aux0 | h->T_rd_sae, vmm_src);
         h->vcvtdq2ps(vmm_aux0, vmm_aux0);
-
-        h->vcmpps(k_mask, vmm_aux0, vmm_src, _cmp_nle_us);
-        h->vmovups(vmm_aux3 | k_mask | h->T_z, table_val(0));
-
-        h->vsubps(vmm_aux0, vmm_aux0, vmm_aux3);
     } else {
         h->uni_vroundps(vmm_aux0, vmm_src, _op_floor);
     }

--- a/src/cpu/jit_uni_eltwise.cpp
+++ b/src/cpu/jit_uni_eltwise.cpp
@@ -140,12 +140,7 @@ void jit_uni_eltwise_injector_f32<isa>::exp_compute_vector(const Vmm &vmm_src) {
     h->uni_vaddps(vmm_src, vmm_src, table_val(1));
 
     // tmp = floorf(fx)
-    if (isa == avx512_common) {
-        h->vcvtps2dq(vmm_aux1 | h->T_rd_sae, vmm_src);
-        h->vcvtdq2ps(vmm_aux1, vmm_aux1);
-    } else {
-        h->uni_vroundps(vmm_aux1, vmm_src, _op_floor);
-    }
+    h->uni_vroundps(vmm_aux1, vmm_src, _op_floor);
 
     //keep fx for further computations
     h->uni_vmovups(vmm_src, vmm_aux1); //vmm_src = fx
@@ -420,12 +415,7 @@ void jit_uni_eltwise_injector_f32<isa>::soft_relu_compute_vector(
     h->uni_vaddps(vmm_src, vmm_src, table_val(1));
 
     // tmp = floorf(fx)
-    if (isa == avx512_common) {
-        h->vcvtps2dq(vmm_aux0 | h->T_rd_sae, vmm_src);
-        h->vcvtdq2ps(vmm_aux0, vmm_aux0);
-    } else {
-        h->uni_vroundps(vmm_aux0, vmm_src, _op_floor);
-    }
+    h->uni_vroundps(vmm_aux0, vmm_src, _op_floor);
 
     // keep fx for further computations
     h->uni_vmovups(vmm_src, vmm_aux0); //vmm_src = fx

--- a/src/cpu/jit_uni_eltwise.cpp
+++ b/src/cpu/jit_uni_eltwise.cpp
@@ -143,11 +143,6 @@ void jit_uni_eltwise_injector_f32<isa>::exp_compute_vector(const Vmm &vmm_src) {
     if (isa == avx512_common) {
         h->vcvtps2dq(vmm_aux1 | h->T_rd_sae, vmm_src);
         h->vcvtdq2ps(vmm_aux1, vmm_aux1);
-
-        h->vcmpps(k_mask, vmm_aux1, vmm_src, _cmp_nle_us);
-        h->vmovups(vmm_aux3 | k_mask | h->T_z, table_val(0));
-
-        h->uni_vsubps(vmm_aux1, vmm_aux1, vmm_aux3);
     } else {
         h->uni_vroundps(vmm_aux1, vmm_src, _op_floor);
     }


### PR DESCRIPTION
`vcvtps2dq(vmm_aux1 | h->T_rd_sae, vmm_src);` rounds down.
Then,

* vcmpps with _cmp_nle_us always returns False
* vmm_aux3 is always set to zero
* vsubps does not change vmm_aux1

So these three mnemonics are not necessary.