### PR TITLE
src: cpu: jit i8 pooling: avx2: fix src load mask for i8 average

### DIFF
--- a/src/cpu/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/jit_uni_i8i8_pooling.cpp
@@ -152,7 +152,7 @@ template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(int ll) {
 
     // extract ll-th part of mask (ll-th QWORD)
-    vpblendd(vreg_mask_q, vreg_zeros, vreg_mask, 0x3 << ll); // 0x3 - mask for 2 x DWORD
+    vpblendd(vreg_mask_q, vreg_zeros, vreg_mask, 0x3 << 2*ll); // 0x3 - mask for 2 x DWORD
 
     // Move mask from ll-th pos to 0-th pos
     if (ll>0)


### PR DESCRIPTION
@tprimak 
please distribute.

Tested together with PR #467 and separately with the following configs:
> --cfg=s8 --cfg=u8
> --dir=FWD_I --tag=acdb --alg=AVG ic23ih60iw60oh31ow31kh3kw4sh2sw2ph1pw1n"wip"
> --dir=FWD_I --tag=acdb --alg=AVG ic14ih60iw60oh31ow31kh3kw2sh2sw2ph1pw1n"wip"
> --dir=FWD_I --tag=acdb --alg=AVG ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1n"wip"
> --dir=FWD_I --tag=acdb --alg=AVG ic14ih60iw60oh31ow31kh2kw3sh2sw2ph1pw1n"wip"
> --dir=FWD_I --tag=acdb --alg=AVG ic25ih60iw60oh31ow31kh2kw4sh2sw2ph1pw1n"wip"
> --dir=FWD_I --tag=acdb --alg=AVG ic28ih60iw60oh31ow31kh4kw2sh2sw2ph1pw1n"wip"

Not tested
> --dir=FWD_I --tag=acdb --alg=AVG ic528ih14oh14kh3ph1n"googlenet_v1:inception_4e/pool"
> 
> #avx2 #slightly incorrect result.
> --dir=BWD_D --tag=aBcd8b --alg=AVG ic17ih60iw60oh31ow31kh4kw3sh2sw2ph1pw1n"wip"

