### PR TITLE
add resize_bilinear support

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -75,6 +75,8 @@ elseif(UNIX OR MINGW)
     append_if(MKLDNN_WERROR CMAKE_CCXX_FLAGS "-Werror")
     append(CMAKE_CCXX_FLAGS "-fvisibility=internal")
     append(CMAKE_CXX_FLAGS "-fvisibility-inlines-hidden")
+    append(CMAKE_CXX_FLAGS "-mavx512f")
+
     # compiler specific settings
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         # Clang cannot vectorize some loops with #pragma omp simd and gets
@@ -166,3 +168,4 @@ if(APPLE)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${_rpath}")
     endforeach()
 endif()
+

--- a/include/mkldnn_types.h
+++ b/include/mkldnn_types.h
@@ -621,6 +621,9 @@ typedef enum {
     mkldnn_rnn,
     /// A matrix multiplication primitive.
     mkldnn_gemm,
+/** A resize_bilinear primitive. */
+mkldnn_resize_bilinear,
+
 } mkldnn_primitive_kind_t;
 
 /// Kinds of algorithms.
@@ -1504,6 +1507,8 @@ typedef enum {
     mkldnn_query_diff_dst_md, ///< destination grad. memory desc
     mkldnn_query_workspace_md, ///< workspace memory desc
     mkldnn_query_scratchpad_md, ///< scratchpad memory desc
+mkldnn_query_resize_bilinear_d, /**< resize_bilinear descriptor */
+
 } mkldnn_query_t;
 
 /// @}
@@ -1542,3 +1547,4 @@ typedef const struct mkldnn_stream *const_mkldnn_stream_t;
 
 
 #endif
+

--- a/include/patch_jit_primitive_conf.hpp
+++ b/include/patch_jit_primitive_conf.hpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef PATCH_JIT_PRIMITIVE_CONF_HPP
+#define PATCH_JIT_PRIMITIVE_CONF_HPP
+
+#include <stdint.h>
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+/* resize_bilinear */
+struct jit_bilinear_conf_t {
+    int ndims;
+    int mb, c;
+    int id, ih, iw, od, oh, ow;
+    int align_corners;
+    bool is_training;
+    bool is_backward;
+    bool simple_alg;
+    data_type_t ind_dt;
+
+    int c_block, c_tail, nb_c;
+    int ur_c, ur_c_tail;
+    int ur_w;
+    int ur_w_tail;
+    size_t tail[4];
+    data_type_t src_dt;
+    data_type_t dst_dt;
+};
+
+struct jit_bilinear_call_s {
+    const float *src;
+    const float *dst;
+    const void *indices;
+    const float *src_prf;
+    const float *dst_prf;
+    const void *indices_prf;
+    size_t oh;
+    const float* init_value;
+    float ker_area_h;
+};
+
+}
+}
+}
+
+#endif

--- a/include/patch_mkldnn.h
+++ b/include/patch_mkldnn.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef PATCH_MKLDNN_H
+#define PATCH_MKLDNN_H
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#include "patch_mkldnn_types.hpp"
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup c_api_resize_bilinear resize_bilinear
+ * A primitive to perform resize_bilinear.
+ * 
+ * @{ */
+
+/** Initializes a resize_bilinear descriptor @p bilinear_desc for forward propagation using
+ * @p prop_kind (possible values are #mkldnn_forward_training or
+ * #mkldnn_forward_inference), @p alg_kind, memory descriptors, and resize_bilinear
+ * parameters in spatial domain: @p strides, @p kernel sizes, @p padding_l, @p
+ * padding_r, and @p padding_kind.
+ *
+ * @note if @p padding_r is @c NULL, the padding is supposed to be symmetric
+ *
+ * @todo clarify! */
+mkldnn_status_t MKLDNN_API mkldnn_resize_bilinear_forward_desc_init(
+        mkldnn_resize_bilinear_desc_t *bilinear_desc, 
+        mkldnn_prop_kind_t prop_kind, /*mkldnn_alg_kind_t alg_kind, */
+        const mkldnn_memory_desc_t *src_desc, const mkldnn_memory_desc_t *dst_desc, 
+        const int *align_corners);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/patch_mkldnn.hpp
+++ b/include/patch_mkldnn.hpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef PATCH_MKLDNN_HPP
+#define PATCH_MKLDNN_HPP
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#include <stdlib.h>
+#include <memory>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+#include <string>
+
+#include "mkldnn.h"
+#include "mkldnn.hpp"
+#include "patch_mkldnn.h"
+#endif
+
+namespace mkldnn {
+
+/// Base class for all computational primitives.
+class patch_primitive: public primitive {
+public:
+    /// A proxy to C primitive kind enum
+    enum class kind {
+        resize_bilinear = mkldnn_resize_bilinear,
+    };
+
+    using primitive::primitive;
+};
+
+enum patch_query {
+    resize_bilinear_d = mkldnn_query_resize_bilinear_d,
+};
+
+/// @addtogroup cpp_api_memory Memory
+/// A primitive to describe data.
+///
+/// @addtogroup cpp_api_resize_bilinear resize_bilinear
+/// A primitive to perform resize_bilinear.
+///
+/// @sa @ref c_api_resize_bilinear in @ref c_api
+/// @{
+
+struct resize_bilinear_forward : public patch_primitive {
+    struct desc {
+        mkldnn_resize_bilinear_desc_t data;
+
+        desc(prop_kind aprop_kind,
+                const memory::desc &src_desc,
+                const memory::desc &dst_desc,
+                const int align_corners) {
+            error::wrap_c_api(mkldnn_resize_bilinear_forward_desc_init(&data,
+                        mkldnn::convert_to_c(aprop_kind),
+                        &src_desc.data, &dst_desc.data,
+                        &align_corners),
+                    "could not init a forward resize_bilinear descriptor");
+        }
+    };
+
+/// Primitive descriptor for resize_bilinear forward propagation.
+    struct primitive_desc : public mkldnn::primitive_desc {
+        primitive_desc() = default;
+
+        primitive_desc(const desc &desc, const engine &e)
+            : mkldnn::primitive_desc(&desc.data, nullptr, e, nullptr) {}
+
+        primitive_desc(const desc &desc, const primitive_attr &attr, const engine &e)
+            : mkldnn::primitive_desc(&desc.data, &attr, e, nullptr) {}
+
+        /// Queries source memory descriptor.
+        memory::desc src_desc() const {
+            return query_md(query::src_md, 0);
+        }
+
+        /// Queries destination memory descriptor.
+        memory::desc dst_desc() const {
+            return query_md(query::dst_md, 0);
+        }
+
+        /// Queries workspace memory descriptor.
+        memory::desc workspace_desc() const {
+            return query_md(query::workspace_md, 0);
+        }
+    };
+
+    resize_bilinear_forward() = default;
+
+    resize_bilinear_forward(const primitive_desc &pd): patch_primitive(pd) {}
+};
+
+/// @}
+
+/// @} C++ API
+
+} // namespace mkldnn
+
+#endif

--- a/include/patch_mkldnn_types.hpp
+++ b/include/patch_mkldnn_types.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef PATCH_MKLDNN_TYPES_H
+#define PATCH_MKLDNN_TYPES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#include <stddef.h>
+#include <stdint.h>
+#include "mkldnn_types.h"
+#endif
+
+/** A descriptor of a resize_bilinear operation. */
+typedef struct {
+    /** The kind of primitive. Used for self identifying the primitive
+     * descriptor. Must be #mkldnn_resize_bilinear. */
+    mkldnn_primitive_kind_t primitive_kind;
+    /** The kind of propagation. Possible values: #mkldnn_forward_training,
+     * #mkldnn_forward_inference, #mkldnn_backward, and #mkldnn_backward_data.
+     */
+    mkldnn_prop_kind_t prop_kind;
+    /** Source memory descriptor. */
+    mkldnn_memory_desc_t src_desc;
+    /** Source gradient memory descriptor. */
+    mkldnn_memory_desc_t diff_src_desc;
+    /** Destination memory descriptor. */
+    mkldnn_memory_desc_t dst_desc;
+    /** Destination gradient memory descriptor. */
+    mkldnn_memory_desc_t diff_dst_desc;
+    /** The accumulator data type. Initialized automatically. */
+    mkldnn_data_type_t accum_data_type;
+    int align_corners;
+} mkldnn_resize_bilinear_desc_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/common/c_types_map.hpp
+++ b/src/common/c_types_map.hpp
@@ -20,6 +20,8 @@
 #include "gemm_types.hpp"
 #include "mkldnn_types.h"
 
+#include "patch_mkldnn_types.hpp"
+
 namespace mkldnn {
 namespace impl {
 
@@ -426,6 +428,8 @@ namespace primitive_kind {
     const primitive_kind_t inner_product = mkldnn_inner_product;
     const primitive_kind_t rnn = mkldnn_rnn;
     const primitive_kind_t gemm = mkldnn_gemm;
+const primitive_kind_t resize_bilinear = mkldnn_resize_bilinear;
+
 }
 
 using query_t = mkldnn_query_t;
@@ -459,6 +463,8 @@ namespace query {
     const query_t rnn_d = mkldnn_query_rnn_d;
     const query_t gemm_d = mkldnn_query_gemm_d;
 
+    const mkldnn_query_t resize_bilinear_d = mkldnn_query_resize_bilinear_d;
+
     const query_t some_md = mkldnn_query_some_md;
     const query_t src_md = mkldnn_query_src_md;
     const query_t diff_src_md = mkldnn_query_diff_src_md;
@@ -485,6 +491,8 @@ using softmax_desc_t = mkldnn_softmax_desc_t;
 using lrn_desc_t = mkldnn_lrn_desc_t;
 using batch_normalization_desc_t = mkldnn_batch_normalization_desc_t;
 using inner_product_desc_t = mkldnn_inner_product_desc_t;
+
+using resize_bilinear_desc_t = mkldnn_resize_bilinear_desc_t;
 
 using rnn_direction_t = mkldnn_rnn_direction_t;
 using rnn_desc_t = mkldnn_rnn_desc_t;
@@ -595,9 +603,12 @@ struct softmax_fwd_pd_t;
 struct softmax_pd_t;
 struct sum_pd_t;
 
+struct resize_bilinear_pd_t;
+
 }
 }
 
 #endif
 
 // vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s
+

--- a/src/common/mkldnn_traits.hpp
+++ b/src/common/mkldnn_traits.hpp
@@ -28,6 +28,8 @@
 #include "z_magic.hpp"
 #include "bfloat16.hpp"
 
+#include "patch_mkldnn.h"
+
 namespace mkldnn {
 namespace impl {
 
@@ -75,6 +77,8 @@ PKIND_TRAITS_INST(lrn);
 PKIND_TRAITS_INST(batch_normalization);
 PKIND_TRAITS_INST(inner_product);
 PKIND_TRAITS_INST(rnn);
+PKIND_TRAITS_INST(resize_bilinear);
+
 PKIND_TRAITS_INST(gemm);
 #undef PKIND_TRAITS_INST
 
@@ -84,3 +88,4 @@ PKIND_TRAITS_INST(gemm);
 #endif
 
 // vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s
+

--- a/src/common/patch_verbose.cpp
+++ b/src/common/patch_verbose.cpp
@@ -1,0 +1,135 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <stdlib.h>
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
+
+#include "mkldnn.h"
+#include "mkldnn_version.h"
+#include "c_types_map.hpp"
+#include "verbose.hpp"
+#include "cpu/cpu_isa_traits.hpp"
+
+#include "resize_bilinear_pd.hpp"
+
+/* MKL-DNN CPU ISA info */
+#define ISA_ANY "No instruction set specific optimizations"
+#define SSE41 "Intel(R) Streaming SIMD Extensions 4.1 (Intel(R) SSE4.1)"
+#define AVX "Intel(R) Advanced Vector Extensions (Intel(R) AVX)"
+#define AVX2 "Intel(R) Advanced Vector Extensions 2 (Intel(R) AVX2)"
+#define AVX512_COMMON "Intel(R) Advanced Vector Extensions 512 (Intel(R) " \
+                      "AVX-512)"
+#define AVX512_CORE "Intel(R) Advanced Vector Extensions 512 (Intel(R) " \
+                    "AVX-512) with AVX512BW, AVX512VL, and AVX512DQ extensions"
+#define AVX512_CORE_VNNI "Intel(R) AVX512-Deep Learning Boost (Intel(R) " \
+                         "AVX512-DL Boost)"
+#define AVX512_MIC "Intel(R) Advanced Vector Extensions 512 (Intel(R) " \
+                   "AVX-512) with AVX512CD, AVX512ER, and AVX512PF extensions"
+#define AVX512_MIC_4OPS "Intel(R) Advanced Vector Extensions 512 (Intel(R) " \
+                   "AVX-512) with AVX512_4FMAPS and AVX512_4VNNIW extensions"
+
+namespace mkldnn {
+namespace impl {
+
+//static verbose_t verbose;
+//static bool initialized;
+//static bool version_printed = false;
+
+/* init_info section */
+namespace {
+#if !defined(DISABLE_VERBOSE)
+#define MKLDNN_VERBOSE_DAT_LEN 256
+#define MKLDNN_VERBOSE_AUX_LEN 384
+#define MKLDNN_VERBOSE_PRB_LEN 384
+
+#define DECL_DAT_AUX_PRB_STRS() \
+    int dat_written = 0, aux_written = 0, prb_written = 0; \
+    MAYBE_UNUSED((dat_written * aux_written * prb_written)); \
+    char dat_str[MKLDNN_VERBOSE_DAT_LEN] = {'\0'}; MAYBE_UNUSED(dat_str); \
+    char aux_str[MKLDNN_VERBOSE_AUX_LEN] = {'\0'}; MAYBE_UNUSED(aux_str); \
+    char prb_str[MKLDNN_VERBOSE_PRB_LEN] = {'\0'}; MAYBE_UNUSED(prb_str)
+
+#define DFMT "%" PRId64
+
+void clear_buf(char *buf, int &written) {
+    /* TODO: do it better */
+    buf[0] = '#';
+    buf[1] = '\0';
+    written = 1;
+}
+
+#define DPRINT(buf, buf_len, written, ...) do { \
+    int l = snprintf(buf + written, buf_len - written, __VA_ARGS__); \
+    if (l < 0 || written + l > buf_len) { \
+        clear_buf(buf, written); \
+    } else { \
+        written += l; \
+    } \
+} while(0)
+
+template <typename pd_t> static void init_info_bilinear(pd_t *s, char *buffer) {
+    DECL_DAT_AUX_PRB_STRS();
+
+    if (1) { // src
+        auto md = s->is_fwd() ? s->src_md() : s->diff_src_md();
+        DPRINT(dat_str, MKLDNN_VERBOSE_DAT_LEN, dat_written, "src_");
+        int l = mkldnn_md2fmt_str(dat_str + dat_written,
+                MKLDNN_VERBOSE_DAT_LEN - dat_written, md);
+        if (l >= 0) dat_written += l; else clear_buf(dat_str, dat_written);
+    }
+    if (1) { // dst
+        auto md = s->is_fwd() ? s->dst_md() : s->diff_dst_md();
+        DPRINT(dat_str, MKLDNN_VERBOSE_DAT_LEN, dat_written, " dst_");
+        int l = mkldnn_md2fmt_str(dat_str + dat_written,
+                MKLDNN_VERBOSE_DAT_LEN - dat_written, md);
+        if (l >= 0) dat_written += l; else clear_buf(dat_str, dat_written);
+    }
+    if (1) { // ws
+        auto md = s->workspace_md();
+        if (md) {
+            DPRINT(dat_str, MKLDNN_VERBOSE_DAT_LEN, dat_written, " ws_");
+            int l = mkldnn_md2fmt_str(dat_str + dat_written,
+                    MKLDNN_VERBOSE_DAT_LEN - dat_written, md);
+            if (l >= 0) dat_written += l; else clear_buf(dat_str, dat_written);
+        }
+    }
+
+    DPRINT(aux_str, MKLDNN_VERBOSE_AUX_LEN, aux_written, "alg");
+}
+
+#undef DPRINT
+
+#else // !defined(DISABLE_VERBOSE)
+
+#define DEFINE_STUB(name) \
+    template <typename pd_t> \
+    static void CONCAT2(init_info_, name)(pd_t *s, char *buffer) \
+    { UNUSED(s); UNUSED(buffer); }
+
+DEFINE_STUB(bilinear);
+#undef DEFINE_STUB
+
+#endif // !defined(DISABLE_VERBOSE)
+}
+
+void init_info(resize_bilinear_pd_t *s, char *b)
+{ init_info_bilinear(s, b); }
+
+}
+}
+

--- a/src/common/resize_bilinear.cpp
+++ b/src/common/resize_bilinear.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <assert.h>
+#include "mkldnn.h"
+#include "patch_mkldnn.h"
+
+#include "c_types_map.hpp"
+#include "type_helpers.hpp"
+#include "utils.hpp"
+
+using namespace mkldnn::impl;
+using namespace mkldnn::impl::utils;
+using namespace mkldnn::impl::status;
+using namespace mkldnn::impl::prop_kind;
+using namespace mkldnn::impl::types;
+
+namespace {
+status_t resize_bilinear_desc_init(resize_bilinear_desc_t *bilinear_desc,
+        prop_kind_t prop_kind,
+        const memory_desc_t *src_desc, const memory_desc_t *dst_desc,
+        const int *align_corners) {
+    bool args_ok = true
+        && !any_null(bilinear_desc, src_desc, dst_desc);
+    if (!args_ok) return invalid_arguments;
+
+    auto pd = resize_bilinear_desc_t();
+    pd.primitive_kind = primitive_kind::resize_bilinear;
+    pd.prop_kind = prop_kind;
+    pd.src_desc.ndims = src_desc->ndims;
+    pd.align_corners = *align_corners;
+
+    const bool is_fwd = one_of(prop_kind, forward_training, forward_inference);
+
+    pd.diff_src_desc = pd.src_desc = zero_md();
+    pd.diff_dst_desc = pd.dst_desc = zero_md();
+
+    (is_fwd ? pd.src_desc : pd.diff_src_desc) = *src_desc;
+    (is_fwd ? pd.dst_desc : pd.diff_dst_desc) = *dst_desc;
+
+    pd.accum_data_type = types::default_accum_data_type(
+            src_desc->data_type, dst_desc->data_type);
+
+    bool consistency = true
+        && src_desc->dims[0] == dst_desc->dims[0]
+        && src_desc->dims[1] == dst_desc->dims[1]
+        && utils::one_of(src_desc->ndims, 4, 5)
+        && utils::one_of(dst_desc->ndims, 4, 5);
+    if (!consistency) return invalid_arguments;
+
+    *bilinear_desc = pd;
+    return success;
+}
+}
+
+status_t mkldnn_resize_bilinear_forward_desc_init(resize_bilinear_desc_t *bilinear_desc,
+        prop_kind_t prop_kind,
+        const memory_desc_t *src_desc, const memory_desc_t *dst_desc,
+        const int *align_corners) {
+    if (!one_of(prop_kind, forward_training, forward_inference))
+        return invalid_arguments;
+
+    return resize_bilinear_desc_init(bilinear_desc, prop_kind, src_desc, dst_desc, align_corners);
+}
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/common/resize_bilinear_pd.hpp
+++ b/src/common/resize_bilinear_pd.hpp
@@ -1,0 +1,204 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef RESIZE_BILINEAR_PD_HPP
+#define RESIZE_BILINEAR_PD_HPP
+
+#include "mkldnn.h"
+#include "patch_mkldnn.hpp"
+
+#include "c_types_map.hpp"
+#include "primitive_desc.hpp"
+#include "type_helpers.hpp"
+
+namespace mkldnn {
+namespace impl {
+
+struct CachedInterpolation {
+    int lower;  // Lower source index used in the interpolation
+    int upper;  // Upper source index used in the interpolation
+    float lerp;
+};
+
+struct resize_bilinear_fwd_pd_t;
+
+struct resize_bilinear_pd_t: public primitive_desc_t {
+    static constexpr auto base_pkind = primitive_kind::resize_bilinear;
+
+    resize_bilinear_pd_t(engine_t *engine,
+            const resize_bilinear_desc_t *adesc, 
+            const primitive_attr_t *attr,
+            const resize_bilinear_fwd_pd_t *hint_fwd_pd)
+        : primitive_desc_t(engine, attr, base_pkind)
+        , desc_(*adesc)
+        , hint_fwd_pd_(hint_fwd_pd)
+        , ws_md_()
+    {}
+
+    const resize_bilinear_desc_t *desc() const { return &desc_; }
+    virtual const op_desc_t *op_desc() const override
+    { return reinterpret_cast<const op_desc_t *>(this->desc()); }
+    virtual void init_info() override { impl::init_info(this, this->info_); }
+
+    virtual status_t query(query_t what, int idx, void *result) const override
+    {
+        switch (what) {
+        case query::resize_bilinear_d:
+            *(const resize_bilinear_desc_t**)result = desc(); break;
+        default: return primitive_desc_t::query(what, idx, result);
+        }
+        return status::success;
+    }
+
+    /* common resize_bilinear aux functions */
+
+    inline int MB() const { return src_desc().dims[0]; }
+    inline int C() const { return src_desc().dims[1]; }
+
+    inline int ID() const { return ndims() >= 5 ? src_desc().dims[ndims() - 3] : 1; }
+    inline int IH() const { return ndims() >= 4 ? src_desc().dims[ndims() - 2] : 1; }
+    inline int IW() const { return src_desc().dims[ndims() - 1]; }
+
+    inline int OD() const { return ndims() >= 5 ? dst_desc().dims[ndims() - 3] : 1; }
+    inline int OH() const { return ndims() >= 4 ? dst_desc().dims[ndims() - 2] : 1; }
+    inline int OW() const { return dst_desc().dims[ndims() - 1]; }
+
+    inline int alignCorners() const { return align_corners(); }
+    inline float RATE(const int _in, const int _out) const {
+        float float_in = _in * 1.0;
+        float scale = 0.0;
+        if (align_corners() && _out > 1)
+            scale = (float_in - 1) / (_out - 1);
+        else
+            scale = float_in / _out;
+
+        return scale;
+    }
+    inline void interpolationWeights(const int in_size, 
+                                    const int out_size, 
+                                    const float scale, 
+                                    CachedInterpolation* interpolation) const {
+        interpolation[out_size].lower = 0;
+        interpolation[out_size].upper = 0;
+        for (int i = out_size - 1; i >= 0; --i) {
+            const float in = i * scale;
+            interpolation[i].lower = static_cast<int>(in);
+            interpolation[i].upper = std::min(interpolation[i].lower + 1, in_size - 1);
+            interpolation[i].lerp = in - interpolation[i].lower;
+        }
+    }
+
+    int ndims() const { return src_desc().ndims; }
+    int spatial_ndims() const { return ndims() - 2; }
+    bool is_3d() const { return ndims() == 5; }
+
+    bool has_zero_dim_memory() const
+    { return memory_desc_wrapper(src_desc()).has_zero_dim(); }
+
+    bool is_fwd() const {
+        return utils::one_of(desc_.prop_kind, prop_kind::forward_training,
+                prop_kind::forward_inference);
+    }
+
+protected:
+    resize_bilinear_desc_t desc_;
+    const resize_bilinear_fwd_pd_t *hint_fwd_pd_;
+
+    memory_desc_t ws_md_;
+
+    void init_default_ws(data_type_t dt = data_type::undef) {
+        ws_md_ = is_fwd() ? *dst_md() : *diff_dst_md();
+        ws_md_.data_type = (dt != data_type::undef) ? dt : indices_data_type();
+    }
+
+    data_type_t indices_data_type() const {
+#if 0
+        /* the simplest way to express 256... */
+        const int u8_max = nstl::numeric_limits<
+            typename prec_traits<data_type::u8>::type>::max();
+        return utils::array_product(desc()->kernel, spatial_ndims()) <= u8_max
+            ? data_type::u8 : data_type::s32;
+#else
+        return data_type::s32;
+#endif
+    }
+
+private:
+    const memory_desc_t &src_desc() const { return desc_.src_desc; }
+    const memory_desc_t &dst_desc() const { return desc_.dst_desc; }
+    const int &align_corners() const { return desc_.align_corners; }
+};
+
+struct resize_bilinear_fwd_pd_t: public resize_bilinear_pd_t {
+    typedef resize_bilinear_fwd_pd_t base_class;
+    typedef resize_bilinear_fwd_pd_t hint_class;
+
+    resize_bilinear_fwd_pd_t(engine_t *engine,
+            const resize_bilinear_desc_t *adesc, 
+            const primitive_attr_t *attr,
+            const resize_bilinear_fwd_pd_t *hint_fwd_pd)
+        : resize_bilinear_pd_t(engine, adesc, attr, hint_fwd_pd)
+        , src_md_(desc_.src_desc)
+        , dst_md_(desc_.dst_desc)
+    {}
+
+    virtual arg_usage_t arg_usage(int arg) const override {
+        if (arg == MKLDNN_ARG_SRC)
+            return arg_usage_t::input;
+
+        if (arg == MKLDNN_ARG_DST)
+            return arg_usage_t::output;
+
+        if (arg == MKLDNN_ARG_WORKSPACE && (workspace_md() != nullptr))
+            return arg_usage_t::output;
+
+        return primitive_desc_t::arg_usage(arg);
+    }
+
+    virtual const memory_desc_t *src_md(int index = 0) const override
+    { return index == 0 ? &src_md_ : nullptr; }
+    virtual const memory_desc_t *dst_md(int index = 0) const override
+    { return index == 0 ? &dst_md_ : nullptr; }
+    virtual const memory_desc_t *workspace_md(int index = 0) const override
+    { return index == 0 && !types::is_zero_md(&ws_md_) ? &ws_md_ : nullptr; }
+
+    virtual int n_inputs() const override { return 1; }
+    virtual int n_outputs() const override
+    { return 1 + (workspace_md() != nullptr); }
+
+protected:
+    memory_desc_t src_md_;
+    memory_desc_t dst_md_;
+
+    virtual status_t set_default_params() {
+        if (dst_md()->format_kind != format_kind::any)
+            return status::success;
+
+        if (src_md()->format_kind != format_kind::blocked)
+            return status::unimplemented;
+
+        return memory_desc_init_by_blocking_desc(dst_md_,
+                src_md_.format_desc.blocking);
+    }
+};
+
+}
+}
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s
+

--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -57,7 +57,10 @@ void init_info(shuffle_pd_t *s, char *buffer);
 void init_info(softmax_pd_t *s, char *buffer);
 void init_info(sum_pd_t *s, char *buffer);
 
+void init_info(resize_bilinear_pd_t *s, char *buffer);
+
 }
 }
 
 #endif
+

--- a/src/cpu/cpu_engine.cpp
+++ b/src/cpu/cpu_engine.cpp
@@ -66,6 +66,10 @@
 #include "cpu/jit_avx512_core_fp32_wino_conv_2x3.hpp"
 #include "cpu/jit_uni_batch_normalization_s8.hpp"
 
+#include "cpu/jit_uni_resize_bilinear.hpp"
+#include "cpu/nchw_resize_bilinear.hpp"
+#include "cpu/nhwc_resize_bilinear.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -278,6 +282,17 @@ static const pd_create_f cpu_impl_list[] = {
     INSTANCE(ref_inner_product_fwd_t<u8, s8, s8, s32>),
     INSTANCE(ref_inner_product_fwd_t<u8, s8, s32, s32>),
     INSTANCE(ref_inner_product_fwd_t<u8, s8, f32, s32>),
+    /* bilinear */
+    INSTANCE(jit_uni_resize_bilinear_fwd_t<avx512_common>),
+    INSTANCE(jit_uni_resize_bilinear_fwd_t<avx2>),
+    INSTANCE(jit_uni_resize_bilinear_fwd_t<sse41>),
+    INSTANCE(nchw_resize_bilinear_fwd_t<f32>),
+    INSTANCE(nchw_resize_bilinear_fwd_t<u8>),
+    INSTANCE(nchw_resize_bilinear_fwd_t<s8>),
+    INSTANCE(nhwc_resize_bilinear_fwd_t<f32>),
+    INSTANCE(nhwc_resize_bilinear_fwd_t<u8>),
+    INSTANCE(nhwc_resize_bilinear_fwd_t<s8>),
+
     /* eol */
     nullptr,
 };
@@ -293,3 +308,4 @@ const pd_create_f* cpu_engine_t::get_implementation_list() const {
 }
 
 // vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s
+

--- a/src/cpu/cpu_resize_bilinear_pd.hpp
+++ b/src/cpu/cpu_resize_bilinear_pd.hpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RESIZE_BILINEAR_PD_HPP
+#define CPU_RESIZE_BILINEAR_PD_HPP
+
+#include "resize_bilinear_pd.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+struct cpu_resize_bilinear_fwd_pd_t: public resize_bilinear_fwd_pd_t {
+    using resize_bilinear_fwd_pd_t::resize_bilinear_fwd_pd_t;
+};
+
+}
+}
+}
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/jit_primitive_conf.hpp
+++ b/src/cpu/jit_primitive_conf.hpp
@@ -21,6 +21,8 @@
 
 #include "common/primitive_attr.hpp"
 
+#include "patch_jit_primitive_conf.hpp"
+
 namespace mkldnn {
 namespace impl {
 namespace cpu {
@@ -489,3 +491,4 @@ struct jit_pool_call_s {
 }
 
 #endif
+

--- a/src/cpu/jit_uni_bilinear_kernel_f32.cpp
+++ b/src/cpu/jit_uni_bilinear_kernel_f32.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "c_types_map.hpp"
+#include "nstl.hpp"
+#include "utils.hpp"
+#include "cpu_resize_bilinear_pd.hpp"
+
+#include "jit_uni_bilinear_kernel_f32.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+using namespace Xbyak;
+
+#define GET_OFF(field) offsetof(jit_bilinear_call_s, field)
+
+template <cpu_isa_t isa>
+status_t jit_uni_bilinear_kernel_f32<isa>::init_conf(jit_bilinear_conf_t &jpp,
+            const resize_bilinear_pd_t *ppd) {
+    const memory_desc_wrapper src_d(
+            ppd->is_fwd() ? ppd->src_md() : ppd->diff_src_md());
+    const memory_desc_wrapper dst_d(
+            ppd->is_fwd() ? ppd->dst_md() : ppd->diff_dst_md());
+
+    const int simd_w = isa == avx512_common ? 16 : 8;
+    jpp.c = utils::rnd_up(src_d.dims()[1], simd_w);
+    jpp.c_block = simd_w;
+    jpp.nb_c = jpp.c / jpp.c_block;
+    return status::success;
+}
+
+
+template struct jit_uni_bilinear_kernel_f32<sse41>;
+template struct jit_uni_bilinear_kernel_f32<avx2>;
+template struct jit_uni_bilinear_kernel_f32<avx512_common>;
+
+}
+}
+}
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/jit_uni_bilinear_kernel_f32.hpp
+++ b/src/cpu/jit_uni_bilinear_kernel_f32.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_JIT_UNI_BILINEAR_KERNEL_F32_HPP
+#define CPU_JIT_UNI_BILINEAR_KERNEL_F32_HPP
+
+#include <cfloat>
+
+#include "c_types_map.hpp"
+#include "resize_bilinear_pd.hpp"
+#include "type_helpers.hpp"
+
+#include "jit_generator.hpp"
+#include "jit_primitive_conf.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+using namespace Xbyak;
+
+template <cpu_isa_t isa>
+struct jit_uni_bilinear_kernel_f32: public jit_generator {
+    jit_uni_bilinear_kernel_f32(jit_bilinear_conf_t ajpp): jpp(ajpp) {}
+
+    jit_bilinear_conf_t jpp;
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_bilinear_kernel_f32)
+
+    void operator()(jit_bilinear_call_s *arg) { jit_ker(arg); }
+    static status_t init_conf(jit_bilinear_conf_t &jbp,
+            const resize_bilinear_pd_t *ppd);
+private:
+    void (*jit_ker)(jit_bilinear_call_s *);
+};
+
+}
+}
+}
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/jit_uni_resize_bilinear.cpp
+++ b/src/cpu/jit_uni_resize_bilinear.cpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifdef __INTEL_COMPILER
+#include <immintrin.h>
+#endif
+
+#include "mkldnn_types.h"
+
+#include "c_types_map.hpp"
+#include "type_helpers.hpp"
+#include "nstl.hpp"
+//#include "utils.hpp"
+
+#include "jit_uni_resize_bilinear.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+template <cpu_isa_t isa>
+void jit_uni_resize_bilinear_fwd_t<isa>::execute_forward(const data_t *src,
+        data_t *dst, char *indices) const {
+printf("avx512/jit_uni_resize_bilinear.cpp\n");
+#if 0
+    auto src = reinterpret_cast<const data_t *>(this->input_memory(0));
+    auto dst = reinterpret_cast<data_t*>(this->memory(0));
+#endif
+    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper indices_d(pd()->workspace_md());
+
+
+    const auto &jpp = pd()->jpp_;
+    const int MB = pd()->MB();
+    const int IC = pd()->C();
+    const int X = jpp.c_block;
+    const int C = jpp.nb_c; // C of n'C'hwxc
+    const int OH = pd()->OH();
+    const int OW = pd()->OW();
+    const int IH = pd()->IH();
+    const int IW = pd()->IW();
+    const float rateH = pd()->RATE(IH, OH);
+    const float rateW = pd()->RATE(IW, OW);
+    std::vector<CachedInterpolation> ys(OH + 1);
+    std::vector<CachedInterpolation> xs(OW + 1);
+    pd()->interpolationWeights(IH, OH, rateH, ys.data());
+    pd()->interpolationWeights(IW, OW, rateW, xs.data());
+
+#ifdef __INTEL_COMPILER
+    auto ker = [&](int _b, int _c, int _oh, int _ow) {
+        __m512 h_lerp = _mm512_set1_ps(ys[_oh].lerp);
+        __m512 w_lerp = _mm512_set1_ps(xs[_ow].lerp);
+
+        long top_left_id     = _b*IH*IW*IC + _c*IH*IW*X + ys[_oh].lower*IW*X + xs[_ow].lower*X;
+        long top_right_id    = _b*IH*IW*IC + _c*IH*IW*X + ys[_oh].lower*IW*X + xs[_ow].upper*X;
+        long bottom_left_id  = _b*IH*IW*IC + _c*IH*IW*X + ys[_oh].upper*IW*X + xs[_ow].lower*X;
+        long bottom_right_id = _b*IH*IW*IC + _c*IH*IW*X + ys[_oh].upper*IW*X + xs[_ow].upper*X;
+        long dst_id          = _b*OH*OW*IC + _c*OH*OW*X + _oh*OW*X + _ow*X;
+
+        __m512 top_left = _mm512_loadu_ps(&src[top_left_id]);
+        __m512 top_right = _mm512_loadu_ps(&src[top_right_id]);
+        __m512 bottom_left = _mm512_loadu_ps(&src[bottom_left_id]);
+        __m512 bottom_right = _mm512_loadu_ps(&src[bottom_right_id]);
+        data_t *d = &dst[dst_id];
+
+        __m512 top = _mm512_sub_ps(top_right, top_left);
+        top = _mm512_mul_ps(top, w_lerp);
+        top = _mm512_add_ps(top_left, top);
+
+        __m512 bottom = _mm512_sub_ps(bottom_right, bottom_left);
+        bottom = _mm512_mul_ps(bottom, w_lerp);
+        bottom = _mm512_add_ps(bottom_left, bottom);
+
+        __m512 val = _mm512_sub_ps(bottom, top);
+        val = _mm512_mul_ps(val, h_lerp);
+        val = _mm512_add_ps(top, val);
+
+        _mm512_storeu_ps(d, val);
+    };
+#else 
+    auto ker = [&](int _b, int _c, int _oh, int _ow, int _x) {
+#if 1
+        const float h_lower = ys[_oh].lower;
+        const float w_lower = xs[_ow].lower;
+        const float h_upper = ys[_oh].upper;
+        const float w_upper = xs[_ow].upper;
+        const float h_lerp = ys[_oh].lerp;
+        const float w_lerp = xs[_ow].lerp;
+
+        long top_left_id     = _b*IH*IW*IC + _c*IH*IW*X + h_lower*IW*X + w_lower*X + _x;
+        long top_right_id    = _b*IH*IW*IC + _c*IH*IW*X + h_lower*IW*X + w_upper*X + _x;
+        long bottom_left_id  = _b*IH*IW*IC + _c*IH*IW*X + h_upper*IW*X + w_lower*X + _x;
+        long bottom_right_id = _b*IH*IW*IC + _c*IH*IW*X + h_upper*IW*X + w_upper*X + _x;
+        long dst_id          = _b*OH*OW*IC + _c*OH*OW*X + _oh*OW*X + _ow*X + _x;
+
+        const float top_left = src[top_left_id];
+        const float top_right = src[top_right_id];
+        const float bottom_left = src[bottom_left_id];
+        const float bottom_right = src[bottom_right_id];
+
+        float top = top_left + (top_right - top_left) * w_lerp;
+        float bottom = bottom_left + (bottom_right - bottom_left) * w_lerp;
+        dst[dst_id] = top + (bottom - top) * h_lerp;
+#else
+        const float top_left = src[src_d.off(_b, _c, ys[_oh].lower, xs[_ow].lower) + _x];
+        const float top_right = src[src_d.off(_b, _c, ys[_oh].lower, xs[_ow].upper) + _x];
+        const float bottom_left = src[src_d.off(_b, _c, ys[_oh].upper, xs[_ow].lower) + _x];
+        const float bottom_right = src[src_d.off(_b, _c, ys[_oh].upper, xs[_ow].upper) + _x];
+
+        float top = top_left + (top_right - top_left) * xs[_ow].lerp;
+        float bottom = bottom_left + (bottom_right - bottom_left) * xs[_ow].lerp;
+
+        dst[dst_d.off(_b, _c, _oh, _ow) + _x] = top + (bottom - top) * ys[_oh].lerp;
+#endif
+    };
+#endif
+
+
+#ifdef __INTEL_COMPILER
+#   pragma omp parallel for collapse(4) schedule(static)
+#else
+#   pragma omp parallel for collapse(5) schedule(static)
+#endif
+    for (int _b = 0; _b < MB; _b ++) {
+        for (int _c = 0; _c < C; _c ++) {
+            for ( int _oh = 0; _oh < OH; _oh ++ ) {
+                for ( int _ow = 0; _ow < OW; _ow ++ ) {
+#ifdef __INTEL_COMPILER
+                    ker(_b, _c, _oh, _ow);
+#else
+                    for ( int _x = 0; _x < X; _x ++ ) ker(_b, _c, _oh, _ow, _x);
+#endif
+                }
+            }
+        }
+    }
+}
+
+template struct jit_uni_resize_bilinear_fwd_t<sse41>;
+template struct jit_uni_resize_bilinear_fwd_t<avx2>;
+template struct jit_uni_resize_bilinear_fwd_t<avx512_common>;
+
+}
+}
+}
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/jit_uni_resize_bilinear.hpp
+++ b/src/cpu/jit_uni_resize_bilinear.hpp
@@ -1,0 +1,104 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_JIT_UNI_RESIZE_BILINEAR_HPP
+#define CPU_JIT_UNI_RESIZE_BILINEAR_HPP
+
+#include <assert.h>
+
+#include "c_types_map.hpp"
+#include "type_helpers.hpp"
+#include "utils.hpp"
+
+#include "cpu_resize_bilinear_pd.hpp"
+#include "cpu_primitive.hpp"
+
+#include "jit_uni_bilinear_kernel_f32.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+template <cpu_isa_t isa>
+struct jit_uni_resize_bilinear_fwd_t: public cpu_primitive_t {
+    struct pd_t: public cpu_resize_bilinear_fwd_pd_t {
+        using cpu_resize_bilinear_fwd_pd_t::cpu_resize_bilinear_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                JIT_IMPL_NAME_HELPER("jit:", isa, ""),
+                jit_uni_resize_bilinear_fwd_t<isa>);
+
+        status_t init() {
+            using namespace utils;
+
+            bool ok = true
+                && set_default_params() == status::success
+                && is_fwd()
+                && attr()->has_default_values()
+                && everyone_is(data_type::f32, src_md()->data_type, dst_md()->data_type)
+                && memory_desc_matches_tag(*src_md(), desired_fmt_tag())
+                && memory_desc_matches_tag(*dst_md(), desired_fmt_tag());
+            if (!ok) return status::unimplemented;
+
+            bool is_training = desc_.prop_kind == prop_kind::forward_training;
+            if (is_training) {
+                init_default_ws();
+            }
+
+            return jit_uni_bilinear_kernel_f32<isa>::init_conf(jpp_, this);
+        }
+
+        format_tag_t desired_fmt_tag()
+        {
+            using namespace format_tag;
+            return ndims() == 4
+                ? isa == avx512_common ? nChw16c : nChw8c
+                : isa == avx512_common ? nCdhw16c : nCdhw8c;
+        }
+
+        jit_bilinear_conf_t jpp_;
+
+    };
+
+    jit_uni_resize_bilinear_fwd_t(const pd_t *apd): cpu_primitive_t(apd)
+    { kernel_ = new jit_uni_bilinear_kernel_f32<isa>(pd()->jpp_); }
+
+    ~jit_uni_resize_bilinear_fwd_t() { delete kernel_; }
+
+    typedef typename prec_traits<data_type::f32>::type data_t;
+    virtual status_t execute(const exec_ctx_t &ctx) const override {
+        auto src = CTX_IN_MEM(const data_t *, MKLDNN_ARG_SRC);
+        auto dst = CTX_OUT_MEM(data_t *, MKLDNN_ARG_DST);
+        auto ws = CTX_OUT_MEM(char *, MKLDNN_ARG_WORKSPACE);
+
+        execute_forward(src, dst, ws);
+
+        return status::success;
+    }
+
+private:
+    void execute_forward(const data_t *src, data_t *dst, char *indices) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
+    jit_uni_bilinear_kernel_f32<isa> *kernel_;
+};
+
+}
+}
+}
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/nchw_resize_bilinear.cpp
+++ b/src/cpu/nchw_resize_bilinear.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <assert.h>
+#include <math.h>
+
+#include "c_types_map.hpp"
+#include "type_helpers.hpp"
+#include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
+#include "nstl.hpp"
+
+#include "nchw_resize_bilinear.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+template <impl::data_type_t data_type>
+void nchw_resize_bilinear_fwd_t<data_type>::execute_forward(
+        const exec_ctx_t &ctx) const {
+    using namespace alg_kind;
+
+    auto src = CTX_IN_MEM(const data_t *, MKLDNN_ARG_SRC);
+    auto dst = CTX_OUT_MEM(data_t *, MKLDNN_ARG_DST);
+
+    const memory_desc_wrapper ws_d(pd()->workspace_md());
+
+    const int MB = pd()->MB();
+    const int C = pd()->C();
+    const int OH = pd()->OH();
+    const int OW = pd()->OW();
+    const int IH = pd()->IH();
+    const int IW = pd()->IW();
+    const float rateH = pd()->RATE(IH, OH);
+    const float rateW = pd()->RATE(IW, OW);
+    std::vector<CachedInterpolation> ys(OH + 1);
+    std::vector<CachedInterpolation> xs(OW + 1);
+    pd()->interpolationWeights(IH, OH, rateH, ys.data());
+    pd()->interpolationWeights(IW, OW, rateW, xs.data());
+
+    auto ker = [&](int _b, int _c, int _oh, int _ow) {
+        const float h_lower = ys[_oh].lower;
+        const float h_upper = ys[_oh].upper;
+        const float h_lerp = ys[_oh].lerp;
+        const float w_lower = xs[_ow].lower;
+        const float w_upper = xs[_ow].upper;
+        const float w_lerp = xs[_ow].lerp;
+
+        long top_left_id = _b*IH*IW*C + _c*IH*IW + h_lower*IW + w_lower;
+        long top_right_id = _b*IH*IW*C + _c*IH*IW + h_lower*IW + w_upper;
+        long bottom_left_id = _b*IH*IW*C + _c*IH*IW + h_upper*IW + w_lower;
+        long bottom_right_id = _b*IH*IW*C + _c*IH*IW + h_upper*IW + w_upper;
+        long dst_id = _b*OH*OW*C + _c*OH*OW + _oh*OW + _ow;
+
+        const float top_left = src[top_left_id];
+        const float top_right = src[top_right_id];
+        const float bottom_left = src[bottom_left_id];
+        const float bottom_right = src[bottom_right_id];
+
+        float top = top_left + (top_right - top_left) * w_lerp;
+        float bottom = bottom_left + (bottom_right - bottom_left) * w_lerp;
+        dst[dst_id] = top + (bottom - top) * h_lerp;
+    };
+
+#   pragma omp parallel for collapse(4) schedule(static)
+    for (int _b = 0; _b < MB; _b ++) {
+        for (int _c = 0; _c < C; _c ++) {
+            for ( int _oh = 0; _oh < OH; _oh ++ ) {
+                for ( int _ow = 0; _ow < OW; _ow ++ ) {
+                    ker(_b, _c, _oh, _ow);
+                }
+            }
+        }
+    }    
+}
+
+template struct nchw_resize_bilinear_fwd_t<data_type::f32>;
+template struct nchw_resize_bilinear_fwd_t<data_type::u8>;
+template struct nchw_resize_bilinear_fwd_t<data_type::s8>;
+
+}
+}
+}
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/nchw_resize_bilinear.hpp
+++ b/src/cpu/nchw_resize_bilinear.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_NCHW_RESIZE_BILINEAR_HPP
+#define CPU_NCHW_RESIZE_BILINEAR_HPP
+
+#include <assert.h>
+
+#include "c_types_map.hpp"
+#include "cpu_resize_bilinear_pd.hpp"
+#include "cpu_engine.hpp"
+#include "type_helpers.hpp"
+#include "utils.hpp"
+
+#include "cpu_pooling_pd.hpp"
+#include "cpu_primitive.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+template <impl::data_type_t data_type>
+struct nchw_resize_bilinear_fwd_t: public cpu_primitive_t {
+    struct pd_t: public cpu_resize_bilinear_fwd_pd_t {
+        using cpu_resize_bilinear_fwd_pd_t::cpu_resize_bilinear_fwd_pd_t;
+        DECLARE_COMMON_PD_T("nchw_resize_bilinear:any", nchw_resize_bilinear_fwd_t);
+
+        status_t init() {
+            const format_tag_t desired_fmt_tag =
+                ndims() == 4 ? format_tag::nchw : format_tag::ncdhw;
+
+            bool ok = true
+                && set_default_params() == status::success
+                && is_fwd()
+                && utils::everyone_is(data_type, src_md()->data_type, dst_md()->data_type)
+                && memory_desc_matches_tag(*dst_md(), desired_fmt_tag)
+                && memory_desc_matches_tag(*src_md(), desired_fmt_tag)
+                && attr()->has_default_values();
+            if (!ok) return status::unimplemented;
+
+            bool is_training = desc_.prop_kind == prop_kind::forward_training;
+            if (is_training) {
+                init_default_ws();
+            }
+
+            return status::success;
+        }
+    };
+
+    nchw_resize_bilinear_fwd_t(const pd_t *apd): cpu_primitive_t(apd) {}
+    typedef typename prec_traits<data_type>::type data_t;
+
+    virtual status_t execute(const exec_ctx_t &ctx) const override {
+        execute_forward(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
+};
+
+}
+}
+}
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/nhwc_resize_bilinear.cpp
+++ b/src/cpu/nhwc_resize_bilinear.cpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifdef __INTEL_COMPILER
+#include <immintrin.h>
+#endif
+
+#include <iostream>
+#include <assert.h>
+#include <math.h>
+
+#include "c_types_map.hpp"
+#include "type_helpers.hpp"
+#include "math_utils.hpp"
+#include "mkldnn_thread.hpp"
+#include "nstl.hpp"
+
+#include "nhwc_resize_bilinear.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+#define MEM_D(name) name##_d
+
+template <impl::data_type_t data_type>
+void nhwc_resize_bilinear_fwd_t<data_type>::execute_forward(
+        const exec_ctx_t &ctx) const {
+    using namespace alg_kind;
+    using namespace prop_kind;
+
+    auto src = CTX_IN_MEM(const data_t *, MKLDNN_ARG_SRC);
+    auto dst = CTX_OUT_MEM(data_t *, MKLDNN_ARG_DST);
+
+    const memory_desc_wrapper MEM_D(src)(pd()->src_md());
+    const memory_desc_wrapper MEM_D(dst)(pd()->dst_md());
+    const memory_desc_wrapper MEM_D(ws)(pd()->workspace_md());
+
+    const int MB = pd()->MB();
+    const int C = pd()->C();
+    const int OH = pd()->OH();
+    const int OW = pd()->OW();
+    const int IH = pd()->IH();
+    const int IW = pd()->IW();
+    const float rateH = pd()->RATE(IH, OH);
+    const float rateW = pd()->RATE(IW, OW);
+    std::vector<CachedInterpolation> ys(OH + 1);
+    std::vector<CachedInterpolation> xs(OW + 1);
+    pd()->interpolationWeights(IH, OH, rateH, ys.data());
+    pd()->interpolationWeights(IW, OW, rateW, xs.data());
+
+#ifdef __INTEL_COMPILER
+    int C_end = C / 16;
+    int C_rest = C % 16;
+
+    auto ker_m512 = [&](int _b, int _oh, int _ow, int _c) {
+        __m512 h_lerp  = _mm512_set1_ps(ys[_oh].lerp);
+        __m512 w_lerp  = _mm512_set1_ps(xs[_ow].lerp);
+
+        int top_left_id = src_d.off(_b, _c, ys[_oh].lower, xs[_ow].lower);
+        int top_right_id = src_d.off(_b, _c, ys[_oh].lower, xs[_ow].upper);
+        int bottom_left_id = src_d.off(_b, _c, ys[_oh].upper, xs[_ow].lower);
+        int bottom_right_id = src_d.off(_b, _c, ys[_oh].upper, xs[_ow].upper);
+        int dst_id = dst_d.off(_b, _c, _oh, _ow);
+
+        __m512 top_left, top_right, bottom_left, bottom_right;
+        for ( int i = 0; i < 16; i ++ ) {
+            top_left[i] = src[top_left_id + i];
+            top_right[i] = src[top_right_id + i];
+            bottom_left[i] = src[bottom_left_id + i];
+            bottom_right[i] = src[bottom_right_id + i];
+        }
+
+        __m512 top = _mm512_sub_ps(top_right, top_left);
+        top = _mm512_mul_ps(top, w_lerp);
+        top = _mm512_add_ps(top_left, top);
+
+        __m512 bottom = _mm512_sub_ps(bottom_right, bottom_left);
+        bottom = _mm512_mul_ps(bottom, w_lerp);
+        bottom = _mm512_add_ps(bottom_left, bottom);
+
+        __m512 val = _mm512_sub_ps(bottom, top);
+        val = _mm512_mul_ps(val, h_lerp);
+        val = _mm512_add_ps(top, val);
+
+        for ( int i = 0; i < 16; i ++ ) dst[dst_id + i] = val[i];
+    };
+#endif
+    auto ker_norm = [&](int _b, int _oh, int _ow, int _c) {
+        const float h_lower = ys[_oh].lower;
+        const float h_upper = ys[_oh].upper;
+        const float h_lerp = ys[_oh].lerp;
+        const float w_lower = xs[_ow].lower;
+        const float w_upper = xs[_ow].upper;
+        const float w_lerp = xs[_ow].lerp;
+
+        long top_left_id     = _b*IH*IW*C + h_lower*IW*C + w_lower*C + _c;
+        long top_right_id    = _b*IH*IW*C + h_lower*IW*C + w_upper*C + _c;
+        long bottom_left_id  = _b*IH*IW*C + h_upper*IW*C + w_lower*C + _c;
+        long bottom_right_id = _b*IH*IW*C + h_upper*IW*C + w_upper*C + _c;
+        long dst_id = _b*OH*OW*C + _oh*OW*C + _ow*C + _c;
+
+        const float top_left = src[top_left_id];
+        const float top_right = src[top_right_id];
+        const float bottom_left = src[bottom_left_id];
+        const float bottom_right = src[bottom_right_id];
+
+        float top = top_left + (top_right - top_left) * w_lerp;
+        float bottom = bottom_left + (bottom_right - bottom_left) * w_lerp;
+        dst[dst_id] = top + (bottom - top) * h_lerp;
+    };
+
+    for (int _b = 0; _b < MB; _b ++) {
+#   pragma omp parallel for collapse(2) schedule(static)
+        for ( int _oh = 0; _oh < OH; _oh ++ ) {
+            for ( int _ow = 0; _ow < OW; _ow ++ ) {
+#   pragma omp simd
+#ifdef __INTEL_COMPILER
+                for (int _c = 0; _c < C_end; _c ++) ker_m512(_b, _oh, _ow, _c*16);
+                if ( C_rest > 0 ) {
+                    for (int _c = C_end*16; _c < C; _c ++) ker_norm(_b, _oh, _ow, _c);
+                }
+#else
+                for (int _c = 0; _c < C; _c ++) ker_norm(_b, _oh, _ow, _c);
+#endif
+            }
+        }
+    }    
+}
+
+template struct nhwc_resize_bilinear_fwd_t<data_type::f32>;
+template struct nhwc_resize_bilinear_fwd_t<data_type::u8>;
+template struct nhwc_resize_bilinear_fwd_t<data_type::s8>;
+
+}
+}
+}
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/src/cpu/nhwc_resize_bilinear.hpp
+++ b/src/cpu/nhwc_resize_bilinear.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+* Copyright 2018 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_NHWC_RESIZE_BILINEAR_HPP
+#define CPU_NHWC_RESIZE_BILINEAR_HPP
+
+#include <assert.h>
+
+#include "c_types_map.hpp"
+#include "cpu_resize_bilinear_pd.hpp"
+#include "cpu_engine.hpp"
+#include "type_helpers.hpp"
+#include "utils.hpp"
+
+#include "cpu_resize_bilinear_pd.hpp"
+#include "cpu_primitive.hpp"
+
+namespace mkldnn {
+namespace impl {
+namespace cpu {
+
+template <impl::data_type_t data_type>
+struct nhwc_resize_bilinear_fwd_t: public cpu_primitive_t {
+    struct pd_t: public cpu_resize_bilinear_fwd_pd_t {
+        using cpu_resize_bilinear_fwd_pd_t::cpu_resize_bilinear_fwd_pd_t;
+        DECLARE_COMMON_PD_T("nhwc_resize_bilinear:any", nhwc_resize_bilinear_fwd_t);
+
+        status_t init() {
+            const format_tag_t desired_fmt_tag =
+                ndims() == 4 ? format_tag::nhwc : format_tag::ndhwc;
+
+            bool ok = true
+                && set_default_params() == status::success
+                && is_fwd()
+                && utils::everyone_is(data_type, src_md()->data_type, dst_md()->data_type)
+                && memory_desc_matches_tag(*dst_md(), desired_fmt_tag)
+                && memory_desc_matches_tag(*src_md(), desired_fmt_tag)
+                && attr()->has_default_values();
+            if (!ok) return status::unimplemented;
+
+            bool is_training = desc_.prop_kind == prop_kind::forward_training;
+            if (is_training) {
+                init_default_ws();
+            }
+
+            return status::success;
+        }
+    };
+
+    nhwc_resize_bilinear_fwd_t(const pd_t *apd): cpu_primitive_t(apd) {}
+    typedef typename prec_traits<data_type>::type data_t;
+
+    virtual status_t execute(const exec_ctx_t &ctx) const override {
+        execute_forward(ctx);
+        return status::success;
+    }
+
+private:
+    void execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd(); }
+};
+
+}
+}
+}
+
+#endif
+
+// vim: et ts=4 sw=4 cindent cino^=l0,\:0,N-s

--- a/tests/generate_c_symbols_refs.sh
+++ b/tests/generate_c_symbols_refs.sh
@@ -20,9 +20,12 @@ output="$2"
 shift 2
 
 echo -e '#include "mkldnn.h"' > "$output"
+echo -e '#include "patch_mkldnn.h"' >> "$output"
+
 echo -e "const void *c_functions[] = {" >> "$output"
 cpp -w "${@/#/-I}" "${mkldnn_root}/include/mkldnn.h" \
     | grep -o 'mkldnn_\w\+(' \
     | sed 's/\(.*\)(/(void*)\1,/g' \
     | sort -u >> "$output"
 echo -e "NULL};\nint main() { return 0; }" >> "$output"
+


### PR DESCRIPTION
Implemented ResizeBilnear, which is equivalent to tf.image.resize_bilinear, while align_corners=False.
(Sorry, as we are not familiar with JIT, thus use the intrinsic functions of AVX512)