### PR TITLE
common: utils: fix potential string truncation in mkldnn_getenv()

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -19,6 +19,7 @@
 #include <malloc.h>
 #include <windows.h>
 #endif
+#include <limits.h>
 
 #include "mkldnn.h"
 #include "utils.hpp"
@@ -30,36 +31,39 @@
 namespace mkldnn {
 namespace impl {
 
-int mkldnn_getenv(char *value, const char *name, int length) {
+int mkldnn_getenv(const char *name, char *buffer, int buffer_size) {
+    if (name == NULL || buffer_size < 0 || (buffer == NULL && buffer_size > 0))
+        return INT_MIN;
+
     int result = 0;
-    int last_idx = 0;
-    if (length > 1) {
-        int value_length = 0;
+    int term_zero_idx = 0;
+    size_t value_length = 0;
+
 #ifdef _WIN32
-        value_length = GetEnvironmentVariable(name, value, length);
-        if (value_length >= length) {
-            result = -value_length;
-        } else {
-            last_idx = value_length;
-            result = value_length;
-        }
+    value_length = GetEnvironmentVariable(name, buffer, buffer_size);
 #else
-        char *buffer = getenv(name);
-        if (buffer != NULL) {
-            value_length = strlen(buffer);
-            if (value_length >= length) {
-                result = -value_length;
-            } else {
-                //Only possible case here is value_length=1, where as length=2, which is fixed array length
-                if(value_length > 0)
-                    strncpy(value, buffer, length-1);
-                last_idx = value_length;
-                result = value_length;
-            }
-        }
+    const char *value = ::getenv(name);
+    value_length = value == NULL ? 0 : strlen(value);
 #endif
+
+    if (value_length > INT_MAX)
+        result = INT_MIN;
+    else {
+        int int_value_length = (int)value_length;
+        if (int_value_length >= buffer_size) {
+            result = -int_value_length;
+        } else {
+            term_zero_idx = int_value_length;
+            result = int_value_length;
+#ifndef _WIN32
+            if (value)
+                strncpy(buffer, value, buffer_size - 1);
+#endif
+        }
     }
-    value[last_idx] = '\0';
+
+    if (buffer != NULL)
+        buffer[term_zero_idx] = '\0';
     return result;
 }
 
@@ -71,7 +75,7 @@ bool mkldnn_jit_dump() {
         const int len = 2;
         char env_dump[len] = {0};
         dump_jit_code =
-            mkldnn_getenv(env_dump, "MKLDNN_JIT_DUMP", len) == 1
+            mkldnn_getenv("MKLDNN_JIT_DUMP", env_dump, len) == 1
             && atoi(env_dump) == 1;
         initialized = true;
     }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -50,7 +50,9 @@ int mkldnn_getenv(char *value, const char *name, int length) {
             if (value_length >= length) {
                 result = -value_length;
             } else {
-                strncpy(value, buffer, value_length);
+                //Only possible case here is value_length=1, where as length=2, which is fixed array length
+                if(value_length > 0)
+                    strncpy(value, buffer, length-1);
                 last_idx = value_length;
                 result = value_length;
             }

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -323,7 +323,30 @@ struct c_compatible {
 
 inline void yield_thread() { }
 
-int mkldnn_getenv(char *value, const char *name, int len);
+// Reads an environment variable 'name' and stores its string value in the
+// 'buffer' of 'buffer_size' bytes (including the terminating zero) on
+// success.
+//
+// - Returns the length of the environment variable string value (excluding
+// the terminating 0) if it is set and its contents (including the terminating
+// 0) can be stored in the 'buffer' without truncation.
+//
+// - Returns negated length of environment variable string value and writes
+// "\0" to the buffer (if it is not NULL) if the 'buffer_size' is to small to
+// store the value (including the terminating 0) without truncation.
+//
+// - Returns 0 and writes "\0" to the buffer (if not NULL) if the environment
+// variable is not set.
+//
+// - Returns INT_MIN if the 'name' is NULL.
+//
+// - Returns INT_MIN if the 'buffer_size' is negative.
+//
+// - Returns INT_MIN if the 'buffer' is NULL and 'buffer_size' is greater than
+// zero. Passing NULL 'buffer' with 'buffer_size' set to 0 can be used to
+// retrieve the length of the environment variable value string.
+//
+int mkldnn_getenv(const char *name, char *buffer, int buffer_size);
 bool mkldnn_jit_dump();
 FILE *mkldnn_fopen(const char *filename, const char *mode);
 

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -53,7 +53,7 @@ const verbose_t *mkldnn_verbose() {
     if (!initialized) {
         const int len = 2;
         char val[len] = {0};
-        if (mkldnn_getenv(val, "MKLDNN_VERBOSE", len) == 1)
+        if (mkldnn_getenv("MKLDNN_VERBOSE", val, len) == 1)
             verbose.level = atoi(val);
         initialized = true;
     }


### PR DESCRIPTION
GCC9 causing build failure:

recipe-sysroot/usr/include/bits/string_fortified.h:106:34: error: 'char* __builtin_strncpy(char*, const char*, long unsigned int)'
output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
|   106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
|       |

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>