### PR TITLE
tests/generate_c-symbols_refs.sh: do not require /bin/bash explicitly

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,7 @@ if(UNIX OR MINGW)
     set(test_c_symbols "${CMAKE_CURRENT_BINARY_DIR}/test_c_symbols.c")
     add_custom_command(
         OUTPUT ${test_c_symbols}
-        COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/generate_c_symbols_refs.sh
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate_c_symbols_refs.sh
         ${CMAKE_CURRENT_SOURCE_DIR}/.. ${test_c_symbols} ${include_dirs}
     )
     register_exe(test_c_symbols-c ${test_c_symbols} "test")

--- a/tests/generate_c_symbols_refs.sh
+++ b/tests/generate_c_symbols_refs.sh
@@ -19,10 +19,12 @@ dnnl_root="$1"
 output="$2"
 shift 2
 
-echo -e '#include "dnnl.h"' > "$output"
-echo -e "const void *c_functions[] = {" >> "$output"
-cpp -w "${@/#/-I}" "${dnnl_root}/include/dnnl.h" \
-    | grep -o 'dnnl_\w\+(' \
-    | sed 's/\(.*\)(/(void*)\1,/g' \
-    | sort -u >> "$output"
-echo -e "NULL};\nint main() { return 0; }" >> "$output"
+{
+    echo '#include "dnnl.h"'
+    echo "const void *c_functions[] = {"
+    cpp -w "${@/#/-I}" "${dnnl_root}/include/dnnl.h" \
+        | grep -o 'dnnl_\w\+(' \
+        | sed 's/\(.*\)(/(void*)\1,/g' \
+        | sort -u
+    printf 'NULL};\nint main() { return 0; }\n'
+} > "$output"


### PR DESCRIPTION
This fixes up the test script and cmake call to just use the shell, rather than
requiring /bin/bash explicitly, and removes some bashisms. This is relevant for
packaging on distributions/containers that may not have this layout. A run of
the script produces the same output as before.


# Checklist

## All Submissions

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
- [X] Have you formatted the code using clang-format?

## New features

- [X] Have you added relevant tests?
- [X] Have you provided motivation for adding a new feature?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?