### PR TITLE
Avoid undefined behavior (UB) bfloat16_t by removing type-pun via union

### DIFF
--- a/src/cpu/bfloat16.cpp
+++ b/src/cpu/bfloat16.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <cstring>
 #include <memory>
 #include "bfloat16.hpp"
 #include "cpu_isa_traits.hpp"
@@ -24,12 +25,6 @@ namespace impl {
 
 using namespace cpu::bf16_support;
 
-union float_raw {
-    float fraw;
-    uint16_t iraw[2];
-    uint32_t int_raw;
-};
-
 bfloat16_t &bfloat16_t::operator=(float f) {
     if (cpu::mayiuse(cpu::cpu_isa_t::avx512_core)) {
         jit_call_t p;
@@ -39,25 +34,29 @@ bfloat16_t &bfloat16_t::operator=(float f) {
                 1);
         cvt_one_ps_to_bf16.jit_ker(&p);
     } else {
-        float_raw r = {f};
+        uint16_t iraw[2];
+        std::memcpy(iraw, &f, sizeof(float));
         switch (std::fpclassify(f)) {
             case FP_SUBNORMAL:
             case FP_ZERO:
                 // sign preserving zero (denormal go to zero)
-                raw_bits_ = r.iraw[1];
+                raw_bits_ = iraw[1];
                 raw_bits_ &= 0x8000;
                 break;
-            case FP_INFINITE: raw_bits_ = r.iraw[1]; break;
+            case FP_INFINITE: raw_bits_ = iraw[1]; break;
             case FP_NAN:
                 // truncate and set MSB of the mantissa force QNAN
-                raw_bits_ = r.iraw[1];
+                raw_bits_ = iraw[1];
                 raw_bits_ |= 1 << 6;
                 break;
             case FP_NORMAL:
                 // round to nearest even and truncate
-                unsigned int rounding_bias = 0x00007FFF + (r.iraw[1] & 0x1);
-                r.int_raw += rounding_bias;
-                raw_bits_ = r.iraw[1];
+                unsigned int rounding_bias = 0x00007FFF + (iraw[1] & 0x1);
+                uint32_t int_raw;
+                std::memcpy(&int_raw, &f, sizeof(float));
+                int_raw += rounding_bias;
+                std::memcpy(iraw, &int_raw, sizeof(float));
+                raw_bits_ = iraw[1];
                 break;
         }
     }
@@ -65,10 +64,10 @@ bfloat16_t &bfloat16_t::operator=(float f) {
 }
 
 bfloat16_t::operator float() const {
-    float_raw r = {0};
-    r.iraw[1] = raw_bits_;
-    r.iraw[0] = 0;
-    return r.fraw;
+    const uint16_t iraw[2] = {0, raw_bits_};
+    float f;
+    std::memcpy(&f, iraw, sizeof(float));
+    return f;
 }
 
 void cvt_float_to_bfloat16(bfloat16_t *out, const float *inp, size_t size) {


### PR DESCRIPTION
Conversions between `float` and `bfloat16_t` were implemented by type-punning (via the union `float_raw`), which caused UB, according to C++ Standard (Working Draft N4849) section [basic.lval]:

> If a program attempts to access the stored value of an object through a glvalue whose type is not similar to one of the following types the behavior is undefined:
> - the dynamic type of the object,
> - a type that is the signed or unsigned type corresponding to the dynamic type of the object, or
> - a char, unsigned char, or std::byte type.

This commit avoids those cases of UB, by replacing type-punning by using `std::memcpy`.

More information:
* CppCon 2019: "Type punning in modern C++", Timur Doumler (@timuraudio), www.youtube.com/watch?v=_qzMpk-22cc
* CppCon 2018: "Undefined Behavior is Not an Error", Barbara Geller (@bgeller) & Ansel Sermersheim (@agserm), www.youtube.com/watch?v=XEXpwis_deQ
