### PR TITLE
[jit] redundant non-negative unroll_y check

### DIFF
--- a/src/cpu/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
+++ b/src/cpu/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
@@ -120,8 +120,7 @@ void jit_avx_gemv_t_f32_kern::innerloop(int unroll_m, int unroll_n) {
 // Outer loop.
 void jit_avx_gemv_t_f32_kern::outerloop(
         int unroll_x, int unroll_y, Label *&cur_outerloop_label) {
-    if ((unroll_x > M_UNROLL_) || (unroll_y > N_UNROLL_) || (unroll_y < 0)
-            || (unroll_y < 0))
+    if ((unroll_x > M_UNROLL_) || (unroll_y > N_UNROLL_) || (unroll_y < 0))
         return;
 
     Label label_m_loop, label_n_loop, label_m_remainder_loops[5];

--- a/src/cpu/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
+++ b/src/cpu/gemm/f32/jit_avx_gemv_t_f32_kern.cpp
@@ -120,7 +120,8 @@ void jit_avx_gemv_t_f32_kern::innerloop(int unroll_m, int unroll_n) {
 // Outer loop.
 void jit_avx_gemv_t_f32_kern::outerloop(
         int unroll_x, int unroll_y, Label *&cur_outerloop_label) {
-    if ((unroll_x > M_UNROLL_) || (unroll_y > N_UNROLL_) || (unroll_y < 0))
+    if ((unroll_x > M_UNROLL_) || (unroll_y > N_UNROLL_) || (unroll_y < 0)
+            || (unroll_x < 0))
         return;
 
     Label label_m_loop, label_n_loop, label_m_remainder_loops[5];


### PR DESCRIPTION
Removed duplicate check for non-negative unroll_y

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/intel/mkl-dnn/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## All Submissions

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
- [ ] Have you formatted the code using clang-format?

## New features

- [ ] Have you added relevant tests?
- [ ] Have you provided motivation for adding a new feature?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?
