### PR TITLE
Prevent constructing signaling NaNs and denormals (subnormal floats) by bfloat16_t

### DIFF
--- a/src/common/bfloat16.hpp
+++ b/src/common/bfloat16.hpp
@@ -31,7 +31,11 @@ namespace impl {
 struct bfloat16_t {
     uint16_t raw_bits_;
     bfloat16_t() = default;
-    constexpr bfloat16_t(uint16_t r, bool) : raw_bits_(r) {}
+    constexpr bfloat16_t(uint16_t r, bool) :
+      raw_bits_{ is_signaling_NaN(r) ? signaling_to_quiet_NaN(r)
+                                     : is_denormal(r) ? make_signed_zero(r)
+                                                      : r }
+    {}
     bfloat16_t(float f) { (*this) = f; }
 
     bfloat16_t DNNL_API &operator=(float f);
@@ -41,6 +45,35 @@ struct bfloat16_t {
     bfloat16_t &operator+=(bfloat16_t a) {
         (*this) = (float)(*this) + (float)a;
         return *this;
+    }
+  private:
+
+    static constexpr uint16_t remove_signbit(const uint16_t r) {
+        return r & 0x7FFF;
+    }
+
+    static constexpr uint16_t signaling_to_quiet_NaN(const uint16_t sNaN) {
+        return sNaN | (1u << 6);
+    }
+
+    static constexpr bool is_signaling_NaN_without_signbit(const uint16_t r) {
+        return (r > 0x7F80) && (r < 0x7FC0);
+    }
+  
+    static constexpr bool is_signaling_NaN(const uint16_t r) {
+        return is_signaling_NaN_without_signbit(remove_signbit(r));
+    }
+
+    static constexpr bool is_denormal_without_signbit(const uint16_t r) {
+        return (r > 0) && (r < (1u << 7));
+    }
+
+    static constexpr bool is_denormal(const uint16_t r) {
+        return is_denormal_without_signbit(remove_signbit(r));
+    }
+
+    static constexpr uint16_t make_signed_zero(const uint16_t r) {
+        return r & (1u << 15);
     }
 };
 


### PR DESCRIPTION
The White Paper [BFLOAT16 – Hardware Numerics Definition](https://software.intel.com/en-us/download/bfloat16-hardware-numerics-definition) (Intel, November 2018) proposed for bfloat16:

> Treat denormal source as zero

And for signaling NaNs (SNANs):
> NaNs and Infinities are supported normally (with SNaNs getting masked response)

If I understand correctly, this implies that `bfloat16_t(r, true)` should not produce a denormal float, or a signalling NaN.

However, the following GoogleTest checks both appear to fail, when using `bfloat16_t` from https://github.com/intel/mkl-dnn/blob/ced4f8895c2b42e1de7cc4252e9f1542467a8d7b/src/common/bfloat16.hpp (Feb 8, 2020):

    EXPECT_NE(std::fpclassify(bfloat16_t(1, true)), FP_SUBNORMAL);
    ASSERT_TRUE(bfloat16_t(1, true) == 0.0f);

So `bfloat16_t(1, true)` does produce a subnormal float, which is clearly unequal to zero.

Moreover, a _signaling_ NaN appears to be producible, for example by `bfloat16_t(0x7F81, true)` or `bfloat16_t(0xFFBF, true)`.

This pull request adjusts the `bfloat16_t(uint16_t, bool)` to prevent producing signalling NaNs and denormal floats in this way. 