### PR TITLE
build: replace unnecessary use of CMake 3.6 feature

### DIFF
--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -26,10 +26,13 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/xbyak
     )
 
-# Don't build sources from linux_perf direcotry if JIT Profiling isn't enabled.
+# Don't enable support for linux_perf and VTune if JIT Profiling is disabled.
 # NOTE: On AArch64 builds. DNNL_ENABLE_JIT_PROFILING=OFF by default.
 if(NOT DNNL_ENABLE_JIT_PROFILING)
-    list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/jit_utils/linux_perf/linux_perf.cpp")
+    list(REMOVE_ITEM SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/jit_utils/jitprofiling/jitprofiling.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/jit_utils/linux_perf/linux_perf.cpp"
+        )
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(
 # Don't build sources from linux_perf direcotry if JIT Profiling isn't enabled.
 # NOTE: On AArch64 builds. DNNL_ENABLE_JIT_PROFILING=OFF by default.
 if(NOT DNNL_ENABLE_JIT_PROFILING)
-    list(FILTER SOURCES EXCLUDE REGEX "linux_perf")
+    list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/jit_utils/linux_perf/linux_perf.cpp")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")


### PR DESCRIPTION
# Description

https://github.com/intel/mkl-dnn/pull/658 introduced a regex list filter to src/cpu/CMakeLists.txt
This feature is only available for Cmake 3.6 onwards which will cause the build to fail if `DNNL_ENABLE_JIT_PROFILING` is not set (e.g. for an AArch64 build) an the host machine has CMake 3.5 or older.

This patch replaces with `filter(REMOVE_ITEM ...` for compatibility with older versions of Cmake.

Note: this should not be encountered by the standard commit tests. Builds on AArch64 will encounter this line, but with no AArch64 CI this will not get tested. I hope to address this with a PR or RFC in the very near future.

Fixes # no issue raised.

# Checklist

## All Submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`)
      pass locally?
_yes, but given it's a CMake change outside the scope of the current CI, it's not entirely relevant.)
- [ ] Have you formatted the code using clang-format?
_no changes made to sources._

## New features

- [ ] Have you added relevant tests?
_not applicable_
- [ ] Have you provided motivation for adding a new feature?
_not applicable_
## Bug fixes

- [ ] Have you added relevant regression tests?
_not applicable_
- [ x ] Have you included information on how to reproduce the issue (either in a
      github issue or in this PR)?
